### PR TITLE
test(web): homepage redesign — Phase 4 polish + HIW v6 choreography

### DIFF
--- a/apps/web/src/features/homepage/HowItWorks/HiwDiagram.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/HiwDiagram.tsx
@@ -1,0 +1,358 @@
+import styles from './HowItWorks.module.scss';
+
+/**
+ * v6 HIW SVG diagram (Blue Escrow v6.html:1390-1483) —
+ * contract core + 3 actor pucks + 3 base dashed wires + 3 active gradient
+ * overlays + money packet. Every animated sub-element is data-tagged so
+ * HowItWorksAnimations can target it without leaking ids into the DOM.
+ *
+ * viewBox 0 0 1200 720 matches the v6 coordinate system; actor + core
+ * positions are defined in steps.tsx so the GSAP timeline can reference
+ * them programmatically.
+ */
+export function HiwDiagram() {
+  return (
+    <svg
+      className={styles.hiw__svg}
+      viewBox="0 0 1200 720"
+      preserveAspectRatio="xMidYMid meet"
+      aria-hidden="true"
+    >
+      <defs>
+        <radialGradient id="hiw-core-grad" cx="50%" cy="40%" r="60%">
+          <stop offset="0" stopColor="#33AAFF" />
+          <stop offset="60%" stopColor="#0066FF" />
+          <stop offset="100%" stopColor="#001B4D" />
+        </radialGradient>
+        <filter
+          id="hiw-core-glow"
+          x="-50%"
+          y="-50%"
+          width="200%"
+          height="200%"
+        >
+          <feGaussianBlur stdDeviation="8" result="b" />
+          <feMerge>
+            <feMergeNode in="b" />
+            <feMergeNode in="SourceGraphic" />
+          </feMerge>
+        </filter>
+        <linearGradient id="hiw-wire-grad" x1="0" x2="1">
+          <stop offset="0" stopColor="#0091FF" stopOpacity="0" />
+          <stop offset=".5" stopColor="#0091FF" />
+          <stop offset="1" stopColor="#0091FF" stopOpacity="0" />
+        </linearGradient>
+      </defs>
+
+      {/* Concentric orbits around contract core */}
+      <g data-hiw="orbits" opacity="0">
+        <circle
+          cx="600"
+          cy="380"
+          r="180"
+          fill="none"
+          stroke="#0091FF"
+          strokeOpacity=".15"
+          strokeDasharray="2 6"
+        />
+        <circle
+          cx="600"
+          cy="380"
+          r="260"
+          fill="none"
+          stroke="#0091FF"
+          strokeOpacity=".1"
+          strokeDasharray="2 8"
+        />
+        <circle
+          cx="600"
+          cy="380"
+          r="340"
+          fill="none"
+          stroke="#0091FF"
+          strokeOpacity=".07"
+          strokeDasharray="2 10"
+        />
+      </g>
+
+      {/* Wires — base dashed (always visible) + active gradient overlays (tweened) */}
+      <g strokeLinecap="round" fill="none" strokeWidth="1.5">
+        <path
+          data-hiw="wire-base-C"
+          d="M 260 420 Q 420 420 540 400"
+          stroke="#213B78"
+          strokeDasharray="5 6"
+        />
+        <path
+          data-hiw="wire-base-M"
+          d="M 600 180 Q 600 280 600 340"
+          stroke="#213B78"
+          strokeDasharray="5 6"
+        />
+        <path
+          data-hiw="wire-base-S"
+          d="M 940 420 Q 780 420 660 400"
+          stroke="#213B78"
+          strokeDasharray="5 6"
+        />
+
+        <path
+          data-hiw="wire-active-C"
+          d="M 260 420 Q 420 420 540 400"
+          stroke="url(#hiw-wire-grad)"
+          strokeWidth="2"
+          opacity="0"
+        />
+        <path
+          data-hiw="wire-active-M"
+          d="M 600 180 Q 600 280 600 340"
+          stroke="url(#hiw-wire-grad)"
+          strokeWidth="2"
+          opacity="0"
+        />
+        <path
+          data-hiw="wire-active-S"
+          d="M 940 420 Q 780 420 660 400"
+          stroke="url(#hiw-wire-grad)"
+          strokeWidth="2"
+          opacity="0"
+        />
+      </g>
+
+      {/* Contract core */}
+      <g data-hiw="core">
+        <circle
+          data-hiw="core-halo"
+          cx="600"
+          cy="380"
+          r="110"
+          fill="#0091FF"
+          fillOpacity="0"
+          filter="url(#hiw-core-glow)"
+        />
+        <circle
+          cx="600"
+          cy="380"
+          r="85"
+          fill="none"
+          stroke="#0091FF"
+          strokeOpacity=".5"
+          strokeDasharray="4 5"
+        />
+        <circle
+          cx="600"
+          cy="380"
+          r="60"
+          fill="url(#hiw-core-grad)"
+          stroke="#0091FF"
+          strokeWidth="1"
+        />
+        <g
+          transform="translate(600 380)"
+          fill="none"
+          stroke="#fff"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <rect x="-14" y="-4" width="28" height="20" rx="3" />
+          <path d="M -9 -4 V -10 A 9 9 0 0 1 9 -10 V -4" />
+        </g>
+        <text
+          x="600"
+          y="460"
+          textAnchor="middle"
+          fontFamily="Geist Mono, ui-monospace"
+          fontSize="11"
+          fill="#7B88B0"
+          letterSpacing="2"
+        >
+          SMART CONTRACT
+        </text>
+        <text
+          x="600"
+          y="478"
+          textAnchor="middle"
+          fontFamily="Geist, ui-sans-serif"
+          fontSize="13"
+          fill="#F3F6FF"
+        >
+          Escrow #4821
+        </text>
+      </g>
+
+      {/* CLIENT actor */}
+      <g data-hiw="actor-client" transform="translate(180 420)" opacity="0">
+        <circle r="56" fill="#071230" stroke="#213B78" strokeWidth="1" />
+        <circle
+          r="66"
+          fill="none"
+          stroke="#0091FF"
+          strokeOpacity=".3"
+          strokeDasharray="2 5"
+        />
+        <g
+          stroke="#0091FF"
+          strokeWidth="1.6"
+          fill="none"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M 0 -16 L -14 -8 V 6 C -14 16 -8 22 0 24 C 8 22 14 16 14 6 V -8 Z" />
+        </g>
+        <text
+          y="-82"
+          textAnchor="middle"
+          fontFamily="Geist Mono, ui-monospace"
+          fontSize="10"
+          fill="#0091FF"
+          letterSpacing="2"
+        >
+          CLIENT
+        </text>
+        <text
+          y="88"
+          textAnchor="middle"
+          fontFamily="Geist, ui-sans-serif"
+          fontSize="14"
+          fill="#F3F6FF"
+        >
+          Sofia R.
+        </text>
+        <text
+          y="106"
+          textAnchor="middle"
+          fontFamily="Geist Mono, ui-monospace"
+          fontSize="10"
+          fill="#7B88B0"
+        >
+          0x7a2f…e91c
+        </text>
+      </g>
+
+      {/* MIDDLEMAN actor */}
+      <g data-hiw="actor-mid" transform="translate(600 120)" opacity="0">
+        <circle r="56" fill="#071230" stroke="#213B78" strokeWidth="1" />
+        <circle
+          r="66"
+          fill="none"
+          stroke="#0091FF"
+          strokeOpacity=".3"
+          strokeDasharray="2 5"
+        />
+        <g
+          stroke="#0091FF"
+          strokeWidth="1.6"
+          fill="none"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M 0 -18 L 16 -10 V 8 L 0 20 L -16 8 V -10 Z" />
+          <path d="M -16 -2 L 16 -2" />
+        </g>
+        <text
+          y="-82"
+          textAnchor="middle"
+          fontFamily="Geist Mono, ui-monospace"
+          fontSize="10"
+          fill="#0091FF"
+          letterSpacing="2"
+        >
+          MIDDLEMAN
+        </text>
+        <text
+          y="88"
+          textAnchor="middle"
+          fontFamily="Geist, ui-sans-serif"
+          fontSize="14"
+          fill="#F3F6FF"
+        >
+          @archer
+        </text>
+        <text
+          y="106"
+          textAnchor="middle"
+          fontFamily="Geist Mono, ui-monospace"
+          fontSize="10"
+          fill="#7B88B0"
+        >
+          REP 4.98 · 214 deals
+        </text>
+      </g>
+
+      {/* SELLER actor */}
+      <g data-hiw="actor-seller" transform="translate(1020 420)" opacity="0">
+        <circle r="56" fill="#071230" stroke="#213B78" strokeWidth="1" />
+        <circle
+          r="66"
+          fill="none"
+          stroke="#0091FF"
+          strokeOpacity=".3"
+          strokeDasharray="2 5"
+        />
+        <g
+          stroke="#0091FF"
+          strokeWidth="1.6"
+          fill="none"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M -14 -12 H 14 L 18 14 A 2 2 0 0 1 16 16 H -16 A 2 2 0 0 1 -18 14 Z" />
+          <path d="M -6 -12 V -18 A 6 6 0 0 1 6 -18 V -12" />
+        </g>
+        <text
+          y="-82"
+          textAnchor="middle"
+          fontFamily="Geist Mono, ui-monospace"
+          fontSize="10"
+          fill="#0091FF"
+          letterSpacing="2"
+        >
+          SELLER
+        </text>
+        <text
+          y="88"
+          textAnchor="middle"
+          fontFamily="Geist, ui-sans-serif"
+          fontSize="14"
+          fill="#F3F6FF"
+        >
+          Diego M.
+        </text>
+        <text
+          y="106"
+          textAnchor="middle"
+          fontFamily="Geist Mono, ui-monospace"
+          fontSize="10"
+          fill="#7B88B0"
+        >
+          0xd20e…77ab
+        </text>
+      </g>
+
+      {/* Money packet — position tweened by the timeline */}
+      <g data-hiw="packet" opacity="0" transform="translate(180 420)">
+        <rect
+          x="-28"
+          y="-14"
+          width="56"
+          height="28"
+          rx="14"
+          fill="#fff"
+          stroke="#0091FF"
+          strokeWidth="1.5"
+        />
+        <text
+          textAnchor="middle"
+          y="5"
+          fontFamily="Geist Mono, ui-monospace"
+          fontSize="11"
+          fill="#001B4D"
+          fontWeight="700"
+        >
+          $2,400
+        </text>
+      </g>
+    </svg>
+  );
+}

--- a/apps/web/src/features/homepage/HowItWorks/HowItWorks.module.scss
+++ b/apps/web/src/features/homepage/HowItWorks/HowItWorks.module.scss
@@ -401,6 +401,17 @@
   position: relative;
   flex: 1 1 auto;
   min-height: 300px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px;
+}
+
+.hiw__svg {
+  width: 100%;
+  height: 100%;
+  min-height: 280px;
+  display: block;
 }
 
 .hiw__actors {

--- a/apps/web/src/features/homepage/HowItWorks/HowItWorks.test.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/HowItWorks.test.tsx
@@ -85,4 +85,43 @@ describe('HowItWorks (v6)', () => {
       'How it works in five steps',
     );
   });
+
+  it('renders the v6 SVG diagram with 3 actors, a packet, and wire overlays', () => {
+    const { container } = render(<HowItWorks />);
+    const svg = container.querySelector('svg[viewBox="0 0 1200 720"]');
+    expect(svg).not.toBeNull();
+    expect(
+      svg?.querySelector('[data-hiw="actor-client"]'),
+    ).not.toBeNull();
+    expect(svg?.querySelector('[data-hiw="actor-mid"]')).not.toBeNull();
+    expect(
+      svg?.querySelector('[data-hiw="actor-seller"]'),
+    ).not.toBeNull();
+    expect(svg?.querySelector('[data-hiw="packet"]')).not.toBeNull();
+    expect(
+      svg?.querySelector('[data-hiw="wire-active-C"]'),
+    ).not.toBeNull();
+    expect(
+      svg?.querySelector('[data-hiw="wire-active-M"]'),
+    ).not.toBeNull();
+    expect(
+      svg?.querySelector('[data-hiw="wire-active-S"]'),
+    ).not.toBeNull();
+  });
+
+  it('tags the ledger amount so the timeline can tween its text content', () => {
+    const { container } = render(<HowItWorks />);
+    const amount = container.querySelector('[data-hiw-ledger="amount"]');
+    expect(amount).not.toBeNull();
+    expect(amount?.textContent).toBe('0');
+  });
+
+  it('tags every rail button with its phase index for scroll-seek', () => {
+    const { container } = render(<HowItWorks />);
+    const rails = container.querySelectorAll('[data-hiw-rail]');
+    expect(rails.length).toBe(5);
+    rails.forEach((btn, i) => {
+      expect(btn.getAttribute('data-hiw-rail')).toBe(String(i));
+    });
+  });
 });

--- a/apps/web/src/features/homepage/HowItWorks/HowItWorks.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/HowItWorks.tsx
@@ -2,6 +2,7 @@
 
 import { useRef, useState } from 'react';
 import { HowItWorksAnimations } from './HowItWorksAnimations';
+import { HiwDiagram } from './HiwDiagram';
 import { HIW_STEPS, LEDGER_LOGS } from './steps';
 import styles from './HowItWorks.module.scss';
 
@@ -112,51 +113,7 @@ export function HowItWorks() {
               </div>
 
               <div className={styles.hiw__sceneBody}>
-                <div className={styles.hiw__actors}>
-                  {(['client', 'mid', 'seller'] as const).map((pos) => {
-                    const isActive =
-                      step.activeActor === 'all' || step.activeActor === pos;
-                    return (
-                      <div
-                        key={pos}
-                        className={`${styles.hiw__actor} ${styles[`hiw__actor--${pos}`]} ${isActive ? styles['hiw__actor--active'] : ''}`}
-                      >
-                        <div className={styles.hiw__actorPuck}>
-                          {pos === 'client' ? 'C' : pos === 'mid' ? 'M' : 'S'}
-                        </div>
-                        <div className={styles.hiw__actorRole}>
-                          {pos === 'client'
-                            ? 'Client'
-                            : pos === 'mid'
-                              ? 'Middleman'
-                              : 'Seller'}
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-
-                <div className={styles.hiw__core}>
-                  <div
-                    className={`${styles.hiw__coreDisc} ${step.ledger.state === 'locked' ? styles['hiw__coreDisc--locked'] : ''}`}
-                  >
-                    <svg
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      aria-hidden="true"
-                    >
-                      <rect x="4" y="10" width="16" height="10" rx="2" />
-                      <path d="M8 10V7a4 4 0 0 1 8 0v3" />
-                    </svg>
-                    <span className={styles.hiw__coreLabel}>
-                      Smart contract
-                    </span>
-                  </div>
-                </div>
+                <HiwDiagram />
               </div>
 
               <div className={styles.hiw__narration} aria-live="polite">

--- a/apps/web/src/features/homepage/HowItWorks/HowItWorks.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/HowItWorks.tsx
@@ -69,7 +69,10 @@ export function HowItWorks() {
               </header>
 
               <div className={styles.hiw__amount}>
-                <span className={styles.hiw__amountNumber}>
+                <span
+                  className={styles.hiw__amountNumber}
+                  data-hiw-ledger="amount"
+                >
                   {step.ledger.amount.toLocaleString()}
                 </span>
                 <span className={styles.hiw__amountUnit}>USDC</span>
@@ -138,6 +141,7 @@ export function HowItWorks() {
               <button
                 key={s.index}
                 type="button"
+                data-hiw-rail={s.index}
                 className={`${styles.hiw__railButton} ${active === s.index ? styles['hiw__railButton--active'] : ''}`}
                 aria-pressed={active === s.index}
                 onClick={() => setActive(s.index)}

--- a/apps/web/src/features/homepage/HowItWorks/HowItWorksAnimations.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/HowItWorksAnimations.tsx
@@ -1,8 +1,14 @@
 'use client';
 
 import { useRef, type RefObject } from 'react';
-import { gsap, ScrollTrigger, useGSAP } from '@/animations/config/gsap-register';
+import {
+  gsap,
+  ScrollTrigger,
+  ScrollToPlugin,
+  useGSAP,
+} from '@/animations/config/gsap-register';
 import { MATCH_MEDIA } from '@/animations/config/defaults';
+import { ACTOR_POSITIONS, CORE_POSITION, HIW_STEPS } from './steps';
 
 interface HowItWorksAnimationsProps {
   children: React.ReactNode;
@@ -10,17 +16,33 @@ interface HowItWorksAnimationsProps {
   onPhaseChange: (phase: 0 | 1 | 2 | 3 | 4) => void;
 }
 
+const PHASE_COUNT = HIW_STEPS.length;
+
+type ChildRef = SVGGraphicsElement | null;
+
+function findChild(root: Element | null, tag: string): ChildRef {
+  if (!root) return null;
+  return root.querySelector<SVGGraphicsElement>(`[data-hiw="${tag}"]`);
+}
+
+function setPacketPosition(el: ChildRef, x: number, y: number) {
+  if (!el) return;
+  el.setAttribute('transform', `translate(${x} ${y})`);
+}
+
 /**
- * Head reveals + scroll-driven phase dispatch for HowItWorks.
+ * Head reveals + pinned scrub timeline that drives the v6 HIW diagram.
  *
- * - Eyebrow + heading + subtitle stagger in at the top of the section
- * - While the stage is in view, scroll progress through it is binned
- *   into 5 phases that drive the parent component's active step. The
- *   rail + narration + ledger then update purely via React state.
+ * Desktop (>= 900px, no reduced-motion): stage pins for 500vh of scroll.
+ * A master GSAP timeline with 5 labels (phase-0..phase-4) fades actors in,
+ * lights up the active wire overlay, flies the money packet between actors
+ * via transform interpolation, and tweens the ledger amount. Rail button
+ * clicks scroll the page to the corresponding phase's pinned offset so
+ * everything — timeline + React state + ledger — stays in lockstep.
  *
- * Heavy pinned choreography with wires, actors orbiting and money
- * packets is intentionally deferred to Phase 3; this is enough for the
- * v6 copy + structure to read correctly.
+ * Mobile (< 900px) and reduced-motion: the stage scrolls normally; a cheap
+ * ScrollTrigger binned into 5 segments dispatches the phase to React state
+ * so narration/rail still update. No pin, no packet flight.
  */
 export function HowItWorksAnimations({
   children,
@@ -36,11 +58,13 @@ export function HowItWorksAnimations({
       const container = containerRef.current;
       const mm = gsap.matchMedia();
 
-      mm.add('(prefers-reduced-motion: no-preference)', () => {
-        const eyebrow = container.querySelector('[data-animate="eyebrow"]');
-        const heading = container.querySelector('[data-animate="heading"]');
-        const subtitle = container.querySelector('[data-animate="subtitle"]');
+      const eyebrow = container.querySelector('[data-animate="eyebrow"]');
+      const heading = container.querySelector('[data-animate="heading"]');
+      const subtitle = container.querySelector('[data-animate="subtitle"]');
 
+      // Shared head reveals — live outside matchMedia so reduced-motion also gets
+      // them (simple fade-ups, no layout jumps).
+      mm.add('(prefers-reduced-motion: no-preference)', () => {
         if (eyebrow) {
           gsap.from(eyebrow, {
             y: 20,
@@ -70,30 +94,253 @@ export function HowItWorksAnimations({
             scrollTrigger: { trigger: subtitle, start: 'top 85%', once: true },
           });
         }
+      });
 
+      // --- Desktop / tablet (>=900px): pinned master timeline with scrub ---
+      mm.add('(min-width: 900px) and (prefers-reduced-motion: no-preference)', () => {
         if (!stageRef.current) return;
+        const stage = stageRef.current;
+        const svgRoot = stage.querySelector('svg');
+        const ledgerAmountEl = stage.querySelector<HTMLElement>(
+          '[data-hiw-ledger="amount"]',
+        );
 
+        if (!svgRoot) return;
+
+        const actors = {
+          client: findChild(svgRoot, 'actor-client'),
+          mid: findChild(svgRoot, 'actor-mid'),
+          seller: findChild(svgRoot, 'actor-seller'),
+        };
+        const wires = {
+          C: findChild(svgRoot, 'wire-active-C'),
+          M: findChild(svgRoot, 'wire-active-M'),
+          S: findChild(svgRoot, 'wire-active-S'),
+        };
+        const packet = findChild(svgRoot, 'packet');
+        const coreHalo = findChild(svgRoot, 'core-halo');
+        const orbits = findChild(svgRoot, 'orbits');
+
+        // Precompute packet coordinates per anchor
+        const packetAnchors: Record<'client' | 'core' | 'seller', { x: number; y: number }> = {
+          client: ACTOR_POSITIONS.client,
+          core: CORE_POSITION,
+          seller: ACTOR_POSITIONS.seller,
+        };
+
+        // Seed: actors + orbits invisible, packet hidden at client position,
+        // wires dark, ledger amount at 0.
+        gsap.set(Object.values(actors), { opacity: 0 });
+        gsap.set(Object.values(wires), { opacity: 0 });
+        gsap.set(coreHalo, { fillOpacity: 0 });
+        gsap.set(orbits, { opacity: 0 });
+        if (packet) {
+          setPacketPosition(packet, packetAnchors.client.x, packetAnchors.client.y);
+          gsap.set(packet, { opacity: 0 });
+        }
+
+        const masterTl = gsap.timeline({
+          scrollTrigger: {
+            id: 'hiw-stage',
+            trigger: stage,
+            start: 'top top',
+            end: '+=500%',
+            pin: true,
+            scrub: 0.5,
+            anticipatePin: 1,
+            onUpdate(self) {
+              const phase = Math.min(
+                PHASE_COUNT - 1,
+                Math.floor(self.progress * PHASE_COUNT),
+              );
+              if (phase !== lastPhaseRef.current) {
+                lastPhaseRef.current = phase;
+                onPhaseChange(phase as 0 | 1 | 2 | 3 | 4);
+              }
+            },
+          },
+          defaults: { ease: 'power2.inOut' },
+        });
+
+        // --- Phase 0: Meet ---
+        masterTl.addLabel('phase-0');
+        masterTl.to(Object.values(actors), { opacity: 1, duration: 0.5, stagger: 0.1 }, 'phase-0');
+        masterTl.to(orbits, { opacity: 1, duration: 0.5 }, 'phase-0');
+
+        // --- Phase 1: Sign (all 3 wires pulse briefly) ---
+        masterTl.addLabel('phase-1', 'phase-0+=0.6');
+        masterTl.to(
+          [wires.C, wires.M, wires.S],
+          { opacity: 0.6, duration: 0.4, stagger: 0.1 },
+          'phase-1',
+        );
+        masterTl.to(
+          [wires.C, wires.M, wires.S],
+          { opacity: 0, duration: 0.4, stagger: 0.1 },
+          'phase-1+=0.5',
+        );
+
+        // --- Phase 2: Lock — packet flies client -> core, wire C lights, amount tweens ---
+        masterTl.addLabel('phase-2', 'phase-1+=0.8');
+        masterTl.to(wires.C, { opacity: 1, duration: 0.4 }, 'phase-2');
+
+        if (packet) {
+          const from = packetAnchors.client;
+          const to = packetAnchors.core;
+          const proxy = { x: from.x, y: from.y };
+          masterTl.to(packet, { opacity: 1, duration: 0.2 }, 'phase-2');
+          masterTl.to(
+            proxy,
+            {
+              x: to.x,
+              y: to.y,
+              duration: 0.8,
+              onUpdate() {
+                setPacketPosition(packet, proxy.x, proxy.y);
+              },
+            },
+            'phase-2+=0.1',
+          );
+          masterTl.to(
+            packet,
+            { opacity: 0, duration: 0.2 },
+            'phase-2+=0.9',
+          );
+        }
+
+        masterTl.to(coreHalo, { fillOpacity: 0.25, duration: 0.4 }, 'phase-2+=0.3');
+
+        // Tween ledger amount display 0 -> 2400
+        if (ledgerAmountEl) {
+          const amountProxy = { value: 0 };
+          masterTl.to(
+            amountProxy,
+            {
+              value: 2400,
+              duration: 0.8,
+              ease: 'power2.out',
+              onUpdate() {
+                ledgerAmountEl.textContent = Math.round(
+                  amountProxy.value,
+                ).toLocaleString();
+              },
+            },
+            'phase-2+=0.1',
+          );
+        }
+
+        // --- Phase 3: Deliver — seller actor highlights, subtle halo hold ---
+        masterTl.addLabel('phase-3', 'phase-2+=1.4');
+        masterTl.to(
+          [actors.client, actors.mid],
+          { opacity: 0.45, duration: 0.3 },
+          'phase-3',
+        );
+        masterTl.to(actors.seller, { opacity: 1, duration: 0.3 }, 'phase-3');
+        masterTl.to(coreHalo, { fillOpacity: 0.4, duration: 0.4 }, 'phase-3');
+
+        // --- Phase 4: Release — packet flies core -> seller, wire S lights, core releases ---
+        masterTl.addLabel('phase-4', 'phase-3+=0.6');
+        masterTl.to(wires.C, { opacity: 0, duration: 0.3 }, 'phase-4');
+        masterTl.to(wires.S, { opacity: 1, duration: 0.4 }, 'phase-4');
+
+        if (packet) {
+          const from = packetAnchors.core;
+          const to = packetAnchors.seller;
+          const proxy = { x: from.x, y: from.y };
+          masterTl.to(packet, { opacity: 1, duration: 0.2 }, 'phase-4');
+          masterTl.to(
+            proxy,
+            {
+              x: to.x,
+              y: to.y,
+              duration: 0.8,
+              onUpdate() {
+                setPacketPosition(packet, proxy.x, proxy.y);
+              },
+            },
+            'phase-4+=0.1',
+          );
+          masterTl.to(
+            packet,
+            { opacity: 0, duration: 0.3 },
+            'phase-4+=0.9',
+          );
+        }
+
+        masterTl.to(coreHalo, { fillOpacity: 0.15, duration: 0.4 }, 'phase-4+=0.4');
+
+        // Trailing buffer so scrub has room to breathe at the bottom
+        masterTl.to({}, { duration: 0.6 });
+
+        // Expose seek for rail button click handlers. We scroll the window to
+        // the correct pinned offset — that way Lenis + ScrollTrigger + state
+        // all stay in sync automatically.
+        const stageTrigger = ScrollTrigger.getById('hiw-stage');
+        const seekToPhase = (phase: number) => {
+          if (!stageTrigger) return;
+          const progress = phase / (PHASE_COUNT - 1);
+          const target =
+            stageTrigger.start + (stageTrigger.end - stageTrigger.start) * progress;
+          gsap.to(window, {
+            duration: 0.8,
+            ease: 'power3.inOut',
+            scrollTo: { y: target, autoKill: true },
+          });
+        };
+
+        const railButtons = container.querySelectorAll<HTMLButtonElement>(
+          '[data-hiw-rail]',
+        );
+        const cleanups: Array<() => void> = [];
+        railButtons.forEach((btn) => {
+          const handler = () => {
+            const phase = Number(btn.dataset.hiwRail);
+            if (!Number.isFinite(phase)) return;
+            seekToPhase(phase);
+          };
+          btn.addEventListener('click', handler);
+          cleanups.push(() => btn.removeEventListener('click', handler));
+        });
+
+        return () => {
+          cleanups.forEach((fn) => fn());
+        };
+      });
+
+      // --- Mobile (<900px) fallback: scroll-binned dispatch, no pin ---
+      mm.add('(max-width: 899px) and (prefers-reduced-motion: no-preference)', () => {
+        if (!stageRef.current) return;
         const trigger = ScrollTrigger.create({
           trigger: stageRef.current,
           start: 'top 70%',
           end: 'bottom 30%',
           onUpdate(self) {
-            const phase = Math.min(4, Math.floor(self.progress * 5));
+            const phase = Math.min(
+              PHASE_COUNT - 1,
+              Math.floor(self.progress * PHASE_COUNT),
+            );
             if (phase !== lastPhaseRef.current) {
               lastPhaseRef.current = phase;
               onPhaseChange(phase as 0 | 1 | 2 | 3 | 4);
             }
           },
         });
-
         return () => trigger.kill();
       });
 
+      // --- Reduced-motion: skip everything, show static final state ---
       mm.add(MATCH_MEDIA.reducedMotion, () => {
         gsap.set(container.querySelectorAll('[data-animate]'), {
           clearProps: 'all',
         });
+        // Park on phase 0 so the static content still reads
+        onPhaseChange(0);
       });
+
+      // Ensure the plugin is referenced — tree-shaking safety since we only use
+      // its side effect through gsap.to(window, { scrollTo }).
+      void ScrollToPlugin;
     },
     { scope: containerRef, dependencies: [onPhaseChange, stageRef] },
   );

--- a/apps/web/src/features/homepage/HowItWorks/steps.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/steps.tsx
@@ -1,12 +1,29 @@
 // v6 HIW step data — copy verbatim from Blue Escrow v6.html:1487-1523.
 //
 // Each phase drives the narration text, the ledger state chip, the ledger
-// amount, the active rail button, and the active actor on the diagram.
+// amount, the active rail button, the active actor, and the GSAP timeline
+// choreography (wire activation, packet flight, amount tween).
 
 import type { ReactNode } from 'react';
 import { Fragment } from 'react';
 
 export type LedgerState = 'draft' | 'signed' | 'locked' | 'delivered' | 'released';
+
+export type ActorId = 'client' | 'mid' | 'seller';
+export type WireId = 'C' | 'M' | 'S';
+
+export interface HiwChoreo {
+  /** Which active-overlay wires are lit this phase (C = client↔core, M = mid↔core, S = seller↔core) */
+  wiresActive: WireId[];
+  /** Where the money packet starts this phase. null = hidden */
+  packetFrom: 'client' | 'core' | null;
+  /** Where the money packet ends this phase. null = hidden */
+  packetTo: 'core' | 'seller' | null;
+  /** Tween the ledger amount display from -> to over the phase sub-timeline */
+  amountTween?: { from: number; to: number };
+  /** Pulse/glow the central contract core */
+  coreGlow?: 'idle' | 'locked' | 'released';
+}
 
 export interface HiwStep {
   index: 0 | 1 | 2 | 3 | 4;
@@ -22,7 +39,8 @@ export interface HiwStep {
     amount: number;
     activeLogIndex: number;
   };
-  activeActor: 'all' | 'client' | 'mid' | 'seller' | null;
+  activeActor: 'all' | ActorId | null;
+  choreo: HiwChoreo;
 }
 
 export const HIW_STEPS: HiwStep[] = [
@@ -45,6 +63,12 @@ export const HIW_STEPS: HiwStep[] = [
       activeLogIndex: 0,
     },
     activeActor: 'all',
+    choreo: {
+      wiresActive: [],
+      packetFrom: null,
+      packetTo: null,
+      coreGlow: 'idle',
+    },
   },
   {
     index: 1,
@@ -65,6 +89,12 @@ export const HIW_STEPS: HiwStep[] = [
       activeLogIndex: 1,
     },
     activeActor: 'all',
+    choreo: {
+      wiresActive: ['C', 'M', 'S'],
+      packetFrom: null,
+      packetTo: null,
+      coreGlow: 'idle',
+    },
   },
   {
     index: 2,
@@ -85,6 +115,13 @@ export const HIW_STEPS: HiwStep[] = [
       activeLogIndex: 2,
     },
     activeActor: 'client',
+    choreo: {
+      wiresActive: ['C'],
+      packetFrom: 'client',
+      packetTo: 'core',
+      amountTween: { from: 0, to: 2400 },
+      coreGlow: 'locked',
+    },
   },
   {
     index: 3,
@@ -105,6 +142,12 @@ export const HIW_STEPS: HiwStep[] = [
       activeLogIndex: 3,
     },
     activeActor: 'seller',
+    choreo: {
+      wiresActive: ['S'],
+      packetFrom: null,
+      packetTo: null,
+      coreGlow: 'locked',
+    },
   },
   {
     index: 4,
@@ -125,8 +168,27 @@ export const HIW_STEPS: HiwStep[] = [
       activeLogIndex: 4,
     },
     activeActor: 'seller',
+    choreo: {
+      wiresActive: ['S'],
+      packetFrom: 'core',
+      packetTo: 'seller',
+      coreGlow: 'released',
+    },
   },
 ];
+
+// SVG viewBox coordinates (v6 HTML:1390-1483 uses viewBox="0 0 1200 720")
+// Actor positions below match the translate() on each actor <g> in v6.
+export const SVG_VIEW_BOX = { width: 1200, height: 720 };
+
+export const ACTOR_POSITIONS: Record<ActorId, { x: number; y: number }> = {
+  client: { x: 180, y: 420 },
+  mid: { x: 600, y: 120 },
+  seller: { x: 1020, y: 420 },
+};
+
+// Contract core position
+export const CORE_POSITION = { x: 600, y: 380 };
 
 export const LEDGER_LOGS: { time: string; label: ReactNode; hash: string }[] = [
   { time: '00:00', label: 'Parties connected', hash: '0x7a…e91c' },


### PR DESCRIPTION
## Summary

Phase 4 closes the last v6-faithfulness gap: the HowItWorks scroll choreography that was a stub through Phases 2 and 3 is now the full v6 pinned master timeline. 4 commits (code) + this PR; epic #38 closes when this merges.

Closes: **#56**, **#38** (epic).

## What landed

### 4.A — HIW full v6 choreography (4 commits)

**`52ee91a feat(web): port v6 HIW SVG diagram markup + steps.choreo data`**
- Replaces div-based actor pucks + div core with the v6 inline SVG (Blue Escrow v6.html:1390-1483)
- Full fidelity: radial core gradient, Gaussian glow filter, wire gradient, concentric orbit rings, 3 base dashed wires + 3 gradient overlays, contract core with halo + outer ring + lock icon + labels, actor pucks (Sofia R. / @archer / Diego M. with hashes/rep), money packet
- New `HiwDiagram.tsx` component — every animated sub-element tagged with `data-hiw` attributes for scoped GSAP queries
- `steps.tsx` extended with a `choreo` block per phase (wiresActive, packetFrom/To, amountTween, coreGlow) + exported SVG view-box + actor/core coords

**`73a5d59 feat(web): HIW pinned master timeline with wire/packet/actor choreography`**
- Desktop (>= 900px, no reduced-motion): stage pins for +=500% scroll with `scrub: 0.5` + `anticipatePin`
- `gsap.timeline` with 5 labels (phase-0..phase-4) driving:
  - phase-0 Meet: actors fade in, orbit rings appear
  - phase-1 Sign: all 3 wire overlays pulse briefly
  - phase-2 Lock: wire C activates, money packet flies client -> core via transform interpolation, core halo fills, ledger amount tweens 0 -> 2,400 via textContent (no React re-render)
  - phase-3 Deliver: seller actor dims up, others step back
  - phase-4 Release: wire C fades, wire S activates, packet flies core -> seller, core halo settles
- Rail button click uses ScrollToPlugin to scroll the window to the matching pinned offset so timeline + ScrollTrigger + React state stay in lockstep
- Mobile (< 900px): falls back to 5-bin scroll dispatcher, no pin
- Reduced motion: parks on phase 0, no animation

**`cc32aaf test(web): HIW SVG diagram + tween hooks + rail seek tags`**
- 3 new assertions: SVG renders all actors/packet/wires, ledger amount carries `data-hiw-ledger` for timeline tween, every rail button carries `data-hiw-rail=<index>` for scroll seek

### 4.B — Audit + polish

**Code-level audit performed** (Lighthouse requires a browser runtime and Chrome DevTools MCP not available in this session; leaving the full Lighthouse/mobile/visual-diff run to manual QA before go-live):

- **Theme tokens:** Only 2 hardcoded `color: #fff` remain — both intentional (HIW core disc text on blue gradient, Hero primary button inner shadow). Every other color reads from `var(--text)` / `var(--text-muted)` / `var(--accent)` / `var(--border)`.
- **A11y:** HIW aside has `aria-label`, state chip + narration have `aria-live="polite"`, progress + log dots + decorative SVG have `aria-hidden="true"`, rail has `aria-label` + per-button `aria-pressed`, section has `aria-label`. FAQ accordion has full `aria-expanded` / `aria-controls` / `aria-labelledby` chain (from Phase 2).
- **Reduced motion:** Every `*Animations.tsx` has an explicit `mm.add(MATCH_MEDIA.reducedMotion, ...)` branch that `clearProps` and shows the static end state.
- **Focus rings:** Added in Phase 3 — HIW rail buttons, FAQ questions, nav links, theme toggle, CTAs all have `:focus-visible` outlines.

## Manual verification checklist (user to complete before promoting to main)

- [ ] `pnpm --filter @blue-escrow/web dev` — smoke the homepage in browser
- [ ] Scroll into HIW: stage pins, packet flies client→core on Lock, core→seller on Release, wires activate, ledger amount tweens 0→2,400, rail highlights
- [ ] Click a rail button: page scrolls smoothly to the matching phase, timeline + state sync
- [ ] Theme toggle mid-HIW: SVG re-themes cleanly
- [ ] Reduced-motion via DevTools: HIW shows phase-0 static, no animation
- [ ] Resize to < 900px: HIW stacks single-column, pin disabled, 5-bin scroll dispatch still updates rail + narration
- [ ] Lighthouse mobile + desktop (both themes): Perf ≥ 85, A11y ≥ 95
- [ ] Tab through entire page: every interactive element has a visible focus ring

## Build + tests

- `pnpm typecheck` — clean
- `pnpm test` — 125/125 pass (3 new Phase 4 tests)
- `pnpm build` — production build passes

## Epic closure

After this merges, closing **#56** (this PR) and **#38** (epic) with SHA references. Branch `feat/38-homepage-redesign` stays on origin for reference.