### PR TITLE
fix(web): v6 fidelity fixes — Phase 5 (audit-driven)

### DIFF
--- a/apps/web/src/components/layout/Footer/Footer.module.scss
+++ b/apps/web/src/components/layout/Footer/Footer.module.scss
@@ -1,44 +1,91 @@
 @use '../../../styles/settings/variables' as *;
-@use '../../../styles/settings/typography' as *;
-@use '../../../styles/tools/mixins' as *;
+
+// ============================================================================
+// FOOTER — v6 (Blue Escrow v6.html:1754-1767, CSS 1178-1210).
+// Giant outlined "Blue" + italic filled "Escrow." wordmark, then a 4-col grid
+// (tagline + Product + Protocol + Directory), then a bottom bar with a pulsing
+// status line and the legal quick-links.
+// ============================================================================
 
 .footer {
   position: relative;
-  z-index: 2;
-  background: var(--white);
-  padding-block: var(--space-64);
-  border-top: 1px solid var(--gray-border);
+  padding: 60px 0 40px;
+  border-top: 1px solid var(--border);
+  overflow: hidden;
 }
 
-.footer__inner {
+.footer__wrap {
+  width: 100%;
   max-width: var(--container-max);
   margin-inline: auto;
   padding-inline: var(--container-padding);
 }
 
-.footer__columns {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: var(--space-32);
-  margin-block-end: var(--space-48);
+// Giant wordmark — "Blue" outlined via text-stroke, "Escrow." filled italic
+.footer__giant {
+  font-size: clamp(80px, 20vw, 300px);
+  line-height: 0.85;
+  letter-spacing: -0.055em;
+  font-weight: 500;
+  margin: 0 0 60px;
+  color: transparent;
+  -webkit-text-stroke: 1px var(--accent);
+  white-space: nowrap;
+  overflow: hidden;
 
-  @include responsive-max($bp-tablet) {
-    grid-template-columns: 1fr;
-    gap: var(--space-24);
+  @media (max-width: 640px) {
+    margin-bottom: 40px;
   }
 }
 
-.footer__column {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-12);
+.footer__giantEmphasis {
+  font-style: italic;
+  font-weight: 600;
+  letter-spacing: -0.04em;
+  color: var(--text);
+  -webkit-text-stroke: 0;
 }
 
-.footer__columnTitle {
-  @include type-mono-label;
+// 4-column grid: tagline (1.5fr) + 3 link cols
+.footer__top {
+  display: grid;
+  grid-template-columns: 1.5fr repeat(3, 1fr);
+  gap: 48px;
+  padding-bottom: 48px;
+  border-bottom: 1px solid var(--border);
 
-  color: var(--black);
+  @media (max-width: 820px) {
+    grid-template-columns: 1fr 1fr;
+    gap: 32px;
+  }
+
+  @media (max-width: 480px) {
+    grid-template-columns: 1fr;
+    gap: 24px;
+  }
+}
+
+.footer__tagline {
+  font-size: 16px;
+  color: var(--text-muted);
+  line-height: 1.55;
+  max-width: 36ch;
   margin: 0;
+}
+
+.footer__col {
+  display: flex;
+  flex-direction: column;
+}
+
+.footer__colHeading {
+  font-family: var(--ff-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-muted);
+  margin: 0 0 16px;
+  font-weight: 500;
 }
 
 .footer__list {
@@ -47,58 +94,93 @@
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: var(--space-8);
+  gap: 10px;
+  font-size: 14px;
 }
 
 .footer__link {
-  @include type-body-sm;
-
-  color: var(--gray-text);
+  color: var(--text);
+  opacity: 0.8;
   text-decoration: none;
-  transition: color 250ms ease;
+  transition:
+    opacity 0.2s,
+    color 0.2s;
 
   &:hover {
-    color: var(--blue-primary);
+    opacity: 1;
+    color: var(--accent);
   }
 
   &:focus-visible {
-    @include focus-ring;
+    outline: 2px solid var(--accent);
+    outline-offset: 4px;
+    border-radius: 2px;
   }
 }
 
+// Bottom bar
 .footer__bottom {
   display: flex;
+  justify-content: space-between;
   align-items: center;
-  gap: var(--space-24);
-  padding-block-start: var(--space-24);
-  border-top: 1px solid var(--gray-border);
+  padding-top: 24px;
+  font-family: var(--ff-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+  flex-wrap: wrap;
+  gap: 12px;
+}
 
-  @include responsive-max($bp-tablet) {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: var(--space-12);
+.footer__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+
+  &::before {
+    content: '';
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--status-success);
+    box-shadow: 0 0 8px var(--status-success);
+    animation: footerStatusPulse 1.8s ease-in-out infinite;
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+    }
   }
 }
 
-.footer__logo {
-  @include type-mono-label;
-
-  color: var(--black);
+@keyframes footerStatusPulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
 }
 
-.footer__copyright {
-  @include type-caption;
-
-  color: var(--gray-text);
+.footer__legal {
+  display: flex;
+  gap: 24px;
+  flex-wrap: wrap;
 }
 
-.footer__badge {
-  @include type-mono-tag;
+.footer__legalLink {
+  color: var(--text-muted);
+  text-decoration: none;
+  transition:
+    opacity 0.2s,
+    color 0.2s;
 
-  color: var(--blue-primary);
-  margin-inline-start: auto;
+  &:hover {
+    color: var(--accent);
+  }
 
-  @include responsive-max($bp-tablet) {
-    margin-inline-start: 0;
+  &:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 4px;
+    border-radius: 2px;
   }
 }

--- a/apps/web/src/components/layout/Footer/Footer.test.tsx
+++ b/apps/web/src/components/layout/Footer/Footer.test.tsx
@@ -4,30 +4,87 @@ import { Footer } from './Footer';
 
 afterEach(cleanup);
 
-describe('Footer', () => {
+describe('Footer (v6)', () => {
   it('renders the footer landmark', () => {
     render(<Footer />);
     expect(screen.getByRole('contentinfo')).toBeDefined();
   });
 
-  it('renders the logo and copyright', () => {
-    render(<Footer />);
-    const footer = screen.getByRole('contentinfo');
-    expect(within(footer).getByText('Blue Escrow')).toBeDefined();
-    expect(within(footer).getByText(/© \d{4} Blue Escrow/)).toBeDefined();
+  it('renders the giant outlined wordmark with italic Escrow emphasis', () => {
+    const { container } = render(<Footer />);
+    const giant = container.querySelector('[class*="footer__giant"]');
+    expect(giant).not.toBeNull();
+    expect(giant?.textContent).toMatch(/Blue\s+Escrow\./);
+    const emphasis = giant?.querySelector('[class*="footer__giantEmphasis"]');
+    expect(emphasis?.textContent).toBe('Escrow.');
   });
 
-  it('renders the Arbitrum badge', () => {
+  it('renders the v6 tagline verbatim', () => {
     render(<Footer />);
-    const footer = screen.getByRole('contentinfo');
-    expect(within(footer).getByText('Built on Arbitrum')).toBeDefined();
+    expect(
+      screen.getByText(/Programmable trust for people who trade with strangers/),
+    ).toBeDefined();
   });
 
-  it('renders column headings', () => {
+  it('renders the three v6 link columns (Product, Protocol, Directory)', () => {
     render(<Footer />);
     const footer = screen.getByRole('contentinfo');
     expect(within(footer).getByText('Product')).toBeDefined();
-    expect(within(footer).getByText('Resources')).toBeDefined();
-    expect(within(footer).getByText('Legal')).toBeDefined();
+    expect(within(footer).getByText('Protocol')).toBeDefined();
+    expect(within(footer).getByText('Directory')).toBeDefined();
+  });
+
+  it('renders v6 Product links pointing to section anchors', () => {
+    render(<Footer />);
+    const footer = screen.getByRole('contentinfo');
+    expect(
+      within(footer).getByRole('link', { name: 'How it works' }).getAttribute('href'),
+    ).toBe('#hiw');
+    expect(
+      within(footer).getByRole('link', { name: 'Compare' }).getAttribute('href'),
+    ).toBe('#compare');
+    expect(
+      within(footer).getByRole('link', { name: 'Fees' }).getAttribute('href'),
+    ).toBe('#fees');
+    expect(
+      within(footer).getByRole('link', { name: 'Receipts' }).getAttribute('href'),
+    ).toBe('#receipts');
+  });
+
+  it('renders v6 Protocol links (Contract, Audits, Source, Docs)', () => {
+    render(<Footer />);
+    const footer = screen.getByRole('contentinfo');
+    expect(within(footer).getByRole('link', { name: 'Contract' })).toBeDefined();
+    expect(within(footer).getByRole('link', { name: 'Audits' })).toBeDefined();
+    expect(within(footer).getByRole('link', { name: 'Source' })).toBeDefined();
+    expect(within(footer).getByRole('link', { name: 'Docs' })).toBeDefined();
+  });
+
+  it('renders v6 Directory links (middleman discovery + reputation)', () => {
+    render(<Footer />);
+    const footer = screen.getByRole('contentinfo');
+    expect(within(footer).getByRole('link', { name: 'Find a middleman' })).toBeDefined();
+    expect(within(footer).getByRole('link', { name: 'Become one' })).toBeDefined();
+    expect(within(footer).getByRole('link', { name: 'Leaderboard' })).toBeDefined();
+    expect(within(footer).getByRole('link', { name: 'Reputation' })).toBeDefined();
+  });
+
+  it('renders the status bar with "All systems operational · Arbitrum"', () => {
+    render(<Footer />);
+    expect(
+      screen.getByText(/All systems operational · Arbitrum/),
+    ).toBeDefined();
+  });
+
+  it('renders the 4 v6 legal bottom links (Terms, Privacy, Bug bounty, Legal)', () => {
+    render(<Footer />);
+    const footer = screen.getByRole('contentinfo');
+    const legalNav = within(footer).getByRole('navigation', {
+      name: /legal/i,
+    });
+    expect(within(legalNav).getByRole('link', { name: 'Terms' })).toBeDefined();
+    expect(within(legalNav).getByRole('link', { name: 'Privacy' })).toBeDefined();
+    expect(within(legalNav).getByRole('link', { name: 'Bug bounty' })).toBeDefined();
+    expect(within(legalNav).getByRole('link', { name: 'Legal' })).toBeDefined();
   });
 });

--- a/apps/web/src/components/layout/Footer/Footer.tsx
+++ b/apps/web/src/components/layout/Footer/Footer.tsx
@@ -1,36 +1,77 @@
 import Link from 'next/link';
 import styles from './Footer.module.scss';
 
-const FOOTER_LINKS = {
-  Product: [
-    { label: 'How It Works', href: '#how-it-works' },
-    { label: 'Features', href: '#features' },
-    { label: 'Pricing', href: '#pricing' },
-  ],
-  Resources: [
-    { label: 'Docs', href: '/docs' },
-    { label: 'GitHub', href: 'https://github.com/blue-escrow' },
-    { label: 'Blog', href: '/blog' },
-  ],
-  Legal: [
-    { label: 'Terms', href: '/terms' },
-    { label: 'Privacy', href: '/privacy' },
-    { label: 'Contact', href: '/contact' },
-  ],
-} as const;
+// v6 footer IA (Blue Escrow v6.html:1754-1767). Three link columns +
+// tagline column; bottom status bar + legal quick-links.
+interface FooterLink {
+  label: string;
+  href: string;
+}
+
+const TAGLINE =
+  'Programmable trust for people who trade with strangers. One contract. Three signatures. Zero middlemen who can run.';
+
+const FOOTER_COLS: { heading: string; links: FooterLink[] }[] = [
+  {
+    heading: 'Product',
+    links: [
+      { label: 'How it works', href: '#hiw' },
+      { label: 'Compare', href: '#compare' },
+      { label: 'Fees', href: '#fees' },
+      { label: 'Receipts', href: '#receipts' },
+    ],
+  },
+  {
+    heading: 'Protocol',
+    links: [
+      { label: 'Contract', href: '/docs/contract' },
+      { label: 'Audits', href: '/docs/audits' },
+      { label: 'Source', href: 'https://github.com/obezeq/blue-escrow' },
+      { label: 'Docs', href: '/docs' },
+    ],
+  },
+  {
+    heading: 'Directory',
+    links: [
+      { label: 'Find a middleman', href: '/middlemen' },
+      { label: 'Become one', href: '/middlemen/apply' },
+      { label: 'Leaderboard', href: '/middlemen/leaderboard' },
+      { label: 'Reputation', href: '/docs/reputation' },
+    ],
+  },
+];
+
+const LEGAL_LINKS: FooterLink[] = [
+  { label: 'Terms', href: '/terms' },
+  { label: 'Privacy', href: '/privacy' },
+  { label: 'Bug bounty', href: '/security' },
+  { label: 'Legal', href: '/legal' },
+];
 
 export function Footer() {
   return (
     <footer className={styles.footer} role="contentinfo">
-      <div className={styles.footer__inner}>
-        <div className={styles.footer__columns}>
-          {Object.entries(FOOTER_LINKS).map(([category, links]) => (
-            <div key={category} className={styles.footer__column}>
-              <h3 className={styles.footer__columnTitle}>{category}</h3>
+      <div className={styles.footer__wrap}>
+        <div className={styles.footer__giant} aria-hidden="true">
+          Blue{' '}
+          <span className={styles.footer__giantEmphasis}>Escrow.</span>
+        </div>
+
+        <div className={styles.footer__top}>
+          <div>
+            <p className={styles.footer__tagline}>{TAGLINE}</p>
+          </div>
+
+          {FOOTER_COLS.map((col) => (
+            <div key={col.heading} className={styles.footer__col}>
+              <h4 className={styles.footer__colHeading}>{col.heading}</h4>
               <ul className={styles.footer__list}>
-                {links.map((link) => (
+                {col.links.map((link) => (
                   <li key={link.label}>
-                    <Link href={link.href} className={styles.footer__link}>
+                    <Link
+                      href={link.href}
+                      className={styles.footer__link}
+                    >
                       {link.label}
                     </Link>
                   </li>
@@ -41,11 +82,23 @@ export function Footer() {
         </div>
 
         <div className={styles.footer__bottom}>
-          <span className={styles.footer__logo}>Blue Escrow</span>
-          <span className={styles.footer__copyright}>
-            &copy; {new Date().getFullYear()} Blue Escrow
-          </span>
-          <span className={styles.footer__badge}>Built on Arbitrum</span>
+          <div className={styles.footer__status} aria-live="polite">
+            All systems operational · Arbitrum
+          </div>
+          <nav
+            className={styles.footer__legal}
+            aria-label="Legal and security links"
+          >
+            {LEGAL_LINKS.map((link) => (
+              <Link
+                key={link.label}
+                href={link.href}
+                className={styles.footer__legalLink}
+              >
+                {link.label}
+              </Link>
+            ))}
+          </nav>
         </div>
       </div>
     </footer>

--- a/apps/web/src/components/layout/Header/Header.module.scss
+++ b/apps/web/src/components/layout/Header/Header.module.scss
@@ -31,7 +31,7 @@
     background: linear-gradient(to bottom, rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0));
   }
 
-  @include responsive-max($bp-tablet) {
+  @include responsive-max($bp-nav) {
     padding: 16px 24px;
   }
 }
@@ -48,7 +48,7 @@
     background: rgba(255, 255, 255, 0.92);
   }
 
-  @include responsive-max($bp-tablet) {
+  @include responsive-max($bp-nav) {
     padding: 14px 24px;
   }
 }
@@ -104,7 +104,7 @@
   font-family: var(--ff-mono);
   font-size: 13px;
 
-  @include responsive-max($bp-tablet) {
+  @include responsive-max($bp-nav) {
     display: none;
   }
 }

--- a/apps/web/src/features/homepage/HeroSection/HeroAnimations.tsx
+++ b/apps/web/src/features/homepage/HeroSection/HeroAnimations.tsx
@@ -4,17 +4,18 @@ import { useRef } from 'react';
 import { gsap, useGSAP } from '@/animations/config/gsap-register';
 import { MATCH_MEDIA } from '@/animations/config/defaults';
 
-// Timing mirrors v6 hero CSS delays (Blue Escrow v6.html CSS 375-377 + 339/398/409/416/455):
-//  - Title words start after the intro overlay finishes (~3.1s)
-//  - Eyebrow / subtitle / CTAs / bottom meta / ticker fade in from 3.9s onward
-// Kept in JS so reduced-motion can bypass the entire sequence cleanly.
-const INTRO_DELAY_WORDS = 3.1;
+// v6 timing, verified against main.js:77-88 + hero.css:375-416:
+//  - Nav fade-in at 3.5s (during intro exit, before title words land)
+//  - Title words lift at 3.9s stagger 0.08, 1.0s, power4.out (v6 CSS delay 3.25/3.42s)
+//  - Supporting rows (eyebrow / sub / ctas / meta / ticker) fade from 3.9s
+const INTRO_DELAY_NAV = 3.5;
+const INTRO_DELAY_WORDS = 3.9;
 const INTRO_DELAY_SUPPORT = 3.9;
 
 /**
  * Client wrapper that animates the v6 hero content after the preloader exits.
- * Words rise into place, supporting rows fade up, then the title parallaxes as
- * the user scrolls past the hero.
+ * Nav fades in first, words rise into place, supporting rows fade up, then
+ * the title parallaxes as the user scrolls past the hero.
  *
  * Under prefers-reduced-motion: reduce, everything is rendered static at
  * CSS defaults — no tweens, no parallax, no ticker scroll.
@@ -29,6 +30,23 @@ export function HeroAnimations({ children }: { children: React.ReactNode }) {
       const mm = gsap.matchMedia();
 
       mm.add(MATCH_MEDIA.noReducedMotion, () => {
+        // Nav intro fade — matches v6 main.js:79 which fades .nav in at
+        // timeline position -0.55s relative to intro exit (~3.5s absolute).
+        // We query outside the scoped container since <Header> lives in the
+        // marketing layout, above HeroSection in the DOM.
+        const nav = document.querySelector<HTMLElement>(
+          'header[class*="header"]',
+        );
+        if (nav) {
+          gsap.set(nav, { autoAlpha: 0 });
+          gsap.to(nav, {
+            autoAlpha: 1,
+            duration: 0.6,
+            ease: 'power2.out',
+            delay: INTRO_DELAY_NAV,
+          });
+        }
+
         const words = container.querySelectorAll<HTMLElement>(
           '[class*="hero__word"]',
         );
@@ -42,9 +60,9 @@ export function HeroAnimations({ children }: { children: React.ReactNode }) {
           gsap.set(words, { yPercent: 115 });
           gsap.to(words, {
             yPercent: 0,
-            duration: 1.2,
-            ease: 'power3.out',
-            stagger: 0.12,
+            duration: 1.0,
+            ease: 'power4.out',
+            stagger: 0.08,
             delay: INTRO_DELAY_WORDS,
           });
         }
@@ -89,15 +107,19 @@ export function HeroAnimations({ children }: { children: React.ReactNode }) {
       });
 
       mm.add(MATCH_MEDIA.reducedMotion, () => {
-        // Static end state: words fully in place, supporting rows visible,
-        // parallax disabled. clearProps removes any yPercent/opacity the
-        // no-preference branch set above if preference flips at runtime.
+        // Static end state: words in place, supporting rows visible, nav
+        // visible, parallax disabled. clearProps removes any yPercent/opacity
+        // the no-preference branch set if the user flips preference at runtime.
         gsap.set(
           container.querySelectorAll(
             '[class*="hero__word"], [data-animate]',
           ),
           { clearProps: 'all' },
         );
+        const nav = document.querySelector<HTMLElement>(
+          'header[class*="header"]',
+        );
+        if (nav) gsap.set(nav, { clearProps: 'all' });
       });
     },
     { scope: containerRef },

--- a/apps/web/src/features/homepage/HeroSection/HeroSection.module.scss
+++ b/apps/web/src/features/homepage/HeroSection/HeroSection.module.scss
@@ -180,7 +180,7 @@
 }
 
 .hero__title {
-  font-size: clamp(56px, 10.8vw, 178px);
+  font-size: clamp(54px, 11vw, 200px);
   line-height: 0.92;
   letter-spacing: -0.045em;
   font-weight: 600;

--- a/apps/web/src/features/homepage/HowItWorks/HiwDiagram.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/HiwDiagram.tsx
@@ -164,7 +164,7 @@ export function HiwDiagram() {
           textAnchor="middle"
           fontFamily="Geist Mono, ui-monospace"
           fontSize="11"
-          fill="#7B88B0"
+          fill="var(--muted-2)"
           letterSpacing="2"
         >
           SMART CONTRACT
@@ -175,7 +175,7 @@ export function HiwDiagram() {
           textAnchor="middle"
           fontFamily="Geist, ui-sans-serif"
           fontSize="13"
-          fill="#F3F6FF"
+          fill="var(--text)"
         >
           Escrow #4821
         </text>

--- a/apps/web/src/features/homepage/HowItWorks/HowItWorksAnimations.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/HowItWorksAnimations.tsx
@@ -128,9 +128,14 @@ export function HowItWorksAnimations({
           seller: ACTOR_POSITIONS.seller,
         };
 
-        // Seed: actors + orbits invisible, packet hidden at client position,
-        // wires dark, ledger amount at 0.
-        gsap.set(Object.values(actors), { opacity: 0 });
+        // Seed: actors + orbits invisible and under-scaled (for the
+        // back.out enter), packet hidden at client position, wires dark,
+        // ledger amount at 0.
+        gsap.set(Object.values(actors), {
+          opacity: 0,
+          scale: 0.9,
+          transformOrigin: '50% 50%',
+        });
         gsap.set(Object.values(wires), { opacity: 0 });
         gsap.set(coreHalo, { fillOpacity: 0 });
         gsap.set(orbits, { opacity: 0 });
@@ -163,8 +168,20 @@ export function HowItWorksAnimations({
         });
 
         // --- Phase 0: Meet ---
+        // Actors pop in with a back.out(1.4) scale + opacity stagger to
+        // match v6 main.js:145-150 ("gsap.from mech-node, back.out, stagger").
         masterTl.addLabel('phase-0');
-        masterTl.to(Object.values(actors), { opacity: 1, duration: 0.5, stagger: 0.1 }, 'phase-0');
+        masterTl.to(
+          Object.values(actors),
+          {
+            opacity: 1,
+            scale: 1,
+            duration: 0.9,
+            stagger: 0.15,
+            ease: 'back.out(1.4)',
+          },
+          'phase-0',
+        );
         masterTl.to(orbits, { opacity: 1, duration: 0.5 }, 'phase-0');
 
         // --- Phase 1: Sign (all 3 wires pulse briefly) ---

--- a/apps/web/src/features/homepage/HowItWorks/HowItWorksAnimations.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/HowItWorksAnimations.tsx
@@ -210,15 +210,17 @@ export function HowItWorksAnimations({
 
         masterTl.to(coreHalo, { fillOpacity: 0.25, duration: 0.4 }, 'phase-2+=0.3');
 
-        // Tween ledger amount display 0 -> 2400
+        // Tween ledger amount display 0 -> 2400.
+        // v6 timing: 2.0s with `power3.out` for a deliberate, money-flows-in
+        // feeling. Phase 4 shipped 0.8s `power2.out` — 2.5x too fast vs design.
         if (ledgerAmountEl) {
           const amountProxy = { value: 0 };
           masterTl.to(
             amountProxy,
             {
               value: 2400,
-              duration: 0.8,
-              ease: 'power2.out',
+              duration: 2.0,
+              ease: 'power3.out',
               onUpdate() {
                 ledgerAmountEl.textContent = Math.round(
                   amountProxy.value,

--- a/apps/web/src/features/homepage/TheProblem/TheProblem.module.scss
+++ b/apps/web/src/features/homepage/TheProblem/TheProblem.module.scss
@@ -80,7 +80,7 @@
     background: var(--status-error);
     transform: scaleX(0);
     transform-origin: left;
-    transition: transform 1s var(--ease-out-expo) 0.35s;
+    transition: transform 1.1s var(--ease-out-expo);
   }
 
   // .problem__line--struck is added by the animation wrapper when the

--- a/apps/web/src/styles/elements/_base.scss
+++ b/apps/web/src/styles/elements/_base.scss
@@ -1,11 +1,13 @@
 // ============================================================================
-// BASE ELEMENT STYLES — Bare HTML elements styled with design tokens
+// BASE ELEMENT STYLES — Bare HTML elements styled with v6 theme tokens.
+// Every color reads from :root[data-theme] so both dark/light themes paint
+// correctly on any unstyled element.
 // ============================================================================
 
 body {
-  background-color: var(--white);
-  color: var(--black);
-  font-family: var(--font-sans), system-ui, -apple-system, sans-serif;
+  background-color: var(--bg-page);
+  color: var(--text);
+  font-family: var(--ff-sans);
   overflow-x: hidden;
   @include type-body;
 }
@@ -14,17 +16,17 @@ body {
 
 h1 {
   @include type-h1;
-  color: var(--section-heading, var(--blue-primary));
+  color: var(--text);
 }
 
 h2 {
   @include type-h2;
-  color: var(--section-heading, var(--blue-primary));
+  color: var(--text);
 }
 
 h3 {
   @include type-h3;
-  color: var(--section-heading, var(--blue-primary));
+  color: var(--text);
 }
 
 h4 {
@@ -45,13 +47,13 @@ h6 {
 // --- Paragraphs ---
 
 p {
-  color: var(--section-text, var(--black));
+  color: var(--text);
 }
 
 // --- Links ---
 
 a {
-  color: var(--blue-primary);
+  color: var(--accent);
   text-decoration: none;
   transition: color var(--transition-fast);
 
@@ -63,21 +65,21 @@ a {
 // --- Inline Code ---
 
 code {
-  font-family: var(--font-mono), ui-monospace, 'Cascadia Code', monospace;
+  font-family: var(--ff-mono);
   font-size: 0.875em;
   padding: 0.125em 0.375em;
-  background: var(--section-code-bg, #eef4ff);
+  background: var(--bg-surface);
   border-radius: var(--radius-sm);
 }
 
 // --- Code Blocks ---
 
 pre {
-  font-family: var(--font-mono), ui-monospace, 'Cascadia Code', monospace;
+  font-family: var(--ff-mono);
   font-size: 0.875rem;
   line-height: 1.6;
   padding: var(--space-16) var(--space-24);
-  background: var(--section-code-bg, #eef4ff);
+  background: var(--bg-surface);
   border-radius: var(--radius-md);
   overflow-x: auto;
 
@@ -91,7 +93,7 @@ pre {
 
 hr {
   border: none;
-  border-block-start: 1px solid var(--section-card-border, var(--gray-border));
+  border-block-start: 1px solid var(--border);
   margin-block: var(--space-32);
 }
 
@@ -105,12 +107,12 @@ b {
 // --- Selection ---
 
 ::selection {
-  background-color: var(--blue-primary);
-  color: var(--white);
+  background-color: var(--accent);
+  color: #fff;
 }
 
 // --- Custom Scrollbar (body) ---
 
 body {
-  @include custom-scrollbar(6px, transparent, var(--gray-border));
+  @include custom-scrollbar(6px, transparent, var(--border));
 }

--- a/apps/web/src/styles/objects/_container.scss
+++ b/apps/web/src/styles/objects/_container.scss
@@ -24,13 +24,9 @@
 .o-section {
   position: relative;
   z-index: 2;
-  padding-block: var(--space-96);
-  background: var(--section-bg);
-  color: var(--section-text);
-
-  @include responsive-max($bp-tablet) {
-    padding-block: var(--space-64);
-  }
+  // Padding intentionally omitted — every homepage section ships its own
+  // vertical rhythm in its .module.scss to match v6's bespoke per-section
+  // paddings (160-200px). .o-section is a positioning anchor only.
 }
 
 // --- Grid ---

--- a/apps/web/src/styles/settings/_typography.scss
+++ b/apps/web/src/styles/settings/_typography.scss
@@ -33,10 +33,12 @@
 
 @mixin type-h2 {
   font-family: var(--font-sans), system-ui, sans-serif;
-  font-size: clamp(1.75rem, 1.21rem + 1.88vw, 3rem);
-  line-height: 1.167;
+  // v6 section-head h2 clamp — reaches 88px at wide viewports.
+  // Previous rem-based formula maxed out at 48px, too small vs design.
+  font-size: clamp(40px, 6.4vw, 88px);
+  line-height: 0.96;
   font-weight: 600;
-  letter-spacing: -0.01em;
+  letter-spacing: -0.035em;
 }
 
 @mixin type-h3 {

--- a/apps/web/src/styles/settings/_variables.scss
+++ b/apps/web/src/styles/settings/_variables.scss
@@ -104,17 +104,6 @@ $bp-section: 900px;
   // (v6 base.css:42-43). Fluid clamp hits both bounds without a breakpoint.
   --container-padding: clamp(1.5rem, 4vw, 2.5rem);
   --header-height:     4.5rem;
-
-  // --- Legacy back-compat (removed in the SectionTransition cleanup commit) ---
-  --white:           #ffffff;
-  --black:           #111111;
-  --gray-text:       #767676;
-  --gray-light:      #f5f7fa;
-  --gray-border:     #e8ecf0;
-  --danger-red:      #ff4455;
-  --role-client:     var(--blue-primary);
-  --role-seller:     var(--blue-text);
-  --role-middleman:  #999999;
 }
 
 // ----------------------------------------------------------------------------
@@ -144,16 +133,6 @@ $bp-section: 900px;
     linear-gradient(180deg, #001b4d 0%, #0b1117 70%);
   --blue-band:
     linear-gradient(135deg, var(--blue-primary) 0%, var(--blue-vivid) 100%);
-
-  // Back-compat contextual aliases — kept until Phase 1 section-class cleanup lands.
-  --section-bg:          var(--bg-page);
-  --section-text:        var(--text);
-  --section-heading:     var(--accent);
-  --section-muted:       var(--text-muted);
-  --section-card-bg:     var(--bg-surface);
-  --section-card-border: var(--border);
-  --section-code-bg:     var(--bg-surface);
-  --section-particle:    var(--accent);
 }
 
 // ----------------------------------------------------------------------------
@@ -182,13 +161,4 @@ $bp-section: 900px;
     linear-gradient(180deg, #e6f1ff 0%, #ffffff 70%);
   --blue-band:
     linear-gradient(135deg, var(--blue-primary) 0%, var(--blue-vivid) 100%);
-
-  --section-bg:          var(--bg-page);
-  --section-text:        var(--text);
-  --section-heading:     var(--accent);
-  --section-muted:       var(--text-muted);
-  --section-card-bg:     var(--bg-surface);
-  --section-card-border: var(--border);
-  --section-code-bg:     var(--bg-tint);
-  --section-particle:    var(--accent);
 }

--- a/apps/web/src/styles/settings/_variables.scss
+++ b/apps/web/src/styles/settings/_variables.scss
@@ -126,6 +126,7 @@ $bp-section: 900px;
   --bg-tint:       #0d2244;
   --text:          #e6edf3;
   --text-muted:    #8b949e;
+  --muted-2:       #556089; // Secondary muted — darker than --text-muted, used in SVG labels (HIW diagram)
   --border:        #1a2740;
   --border-strong: #2a3b5c;
 
@@ -163,6 +164,7 @@ $bp-section: 900px;
   --bg-tint:       #e6f1ff;
   --text:          #0a0a0a;
   --text-muted:    #5a6474;
+  --muted-2:       #8591ad; // Secondary muted in light theme (lighter blue-grey for SVG labels)
   --border:        #e0e4ea;
   --border-strong: #c9d2de;
 

--- a/apps/web/src/styles/settings/_variables.scss
+++ b/apps/web/src/styles/settings/_variables.scss
@@ -100,7 +100,9 @@ $bp-section: 900px;
 
   // --- Layout ---
   --container-max:     1440px;
-  --container-padding: var(--space-24);
+  // v6 wraps use 40px horizontal padding at desktop; mobile shrinks to 24px
+  // (v6 base.css:42-43). Fluid clamp hits both bounds without a breakpoint.
+  --container-padding: clamp(1.5rem, 4vw, 2.5rem);
   --header-height:     4.5rem;
 
   // --- Legacy back-compat (removed in the SectionTransition cleanup commit) ---

--- a/apps/web/src/styles/settings/_variables.scss
+++ b/apps/web/src/styles/settings/_variables.scss
@@ -8,6 +8,14 @@ $bp-desktop: 1024px;
 $bp-wide: 1440px;
 $bp-ultra: 1920px;
 
+// v6-aligned semantic breakpoints (Blue Escrow v6.html CSS uses these):
+// $bp-narrow (720px): wrap padding shrinks, section-head stack
+// $bp-nav    (820px): nav-links collapse, footer top grid 2-col
+// $bp-section (900px): section-head grid 1-col, hiw-head stack
+$bp-narrow:  720px;
+$bp-nav:     820px;
+$bp-section: 900px;
+
 // ============================================================================
 // CSS CUSTOM PROPERTIES — Single source of truth for v6 design tokens
 // ============================================================================

--- a/apps/web/src/styles/tools/_mixins.scss
+++ b/apps/web/src/styles/tools/_mixins.scss
@@ -37,20 +37,20 @@
 }
 
 // ============================================================================
-// SURFACES — Auto-adapt via contextual --section-* vars
+// SURFACES — Read v6 theme tokens directly; reacts to :root[data-theme]
 // ============================================================================
 
 @mixin glass-panel {
-  background: var(--section-card-bg);
+  background: var(--bg-surface);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
-  border: 1px solid var(--section-card-border);
+  border: 1px solid var(--border);
   border-radius: var(--radius-lg);
 }
 
 @mixin surface-card {
-  background: var(--section-card-bg);
-  border: 1px solid var(--section-card-border);
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
   border-radius: var(--radius-lg);
 }
 
@@ -92,7 +92,7 @@
 }
 
 @mixin focus-ring {
-  outline: 2px solid var(--blue-vivid);
+  outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
 
@@ -103,7 +103,7 @@
 @mixin custom-scrollbar(
   $width: 6px,
   $track: transparent,
-  $thumb: var(--gray-border)
+  $thumb: var(--border)
 ) {
   &::-webkit-scrollbar {
     width: $width;

--- a/apps/web/src/styles/utilities/_helpers.scss
+++ b/apps/web/src/styles/utilities/_helpers.scss
@@ -34,11 +34,11 @@
 // --- Text Color Overrides ---
 
 .u-text-muted {
-  color: var(--section-muted) !important;
+  color: var(--text-muted) !important;
 }
 
 .u-text-heading {
-  color: var(--section-heading) !important;
+  color: var(--accent) !important;
 }
 
 // --- Display ---


### PR DESCRIPTION
## Summary

Phase 5 closes the v6 fidelity gaps flagged by the 3-agent audit run after Phase 4. 10 commits. Critical + medium items land; minor cosmetic drifts (hex case, MagneticButton elastic value, Preloader rAF-vs-GSAP) stay as-is.

Closes: **#64**.

## Commits

### 🔴 Critical (from audit)

1. **\`463fc72\` fix(web): restore v6 footer IA with giant brand + tagline + 4-col + status bar** — Giant outlined \"Blue\" + italic filled \"Escrow.\" wordmark, tagline, 4-col grid (tagline + Product/Protocol/Directory with v6-verbatim links), status bar \"All systems operational · Arbitrum\" with pulsing status-success dot, legal bottom links (Terms / Privacy / Bug bounty / Legal). 9 tests covering the v6 IA.

2. **\`a4c24c9\` feat(web): add v6 semantic breakpoints + realign nav collapse to 820px** — New \$bp-narrow/\$bp-nav/\$bp-section tokens mapping to v6's 720/820/900 reflow points. Header nav now hides at 820px (v6) instead of 768px.

3. **\`23cccbb\` fix(web): HIW ledger counter matches v6 timing (2.0s power3.out)** — 0.8s \`power2.out\` → 2.0s \`power3.out\`. 2.5× slower = deliberate; counter was racing before.

4. **\`8b9adf1\` fix(web): HIW SMART CONTRACT label uses theme token + add --muted-2** — Token pair added (dark #556089 / light #8591AD). Fill \`#7B88B0\` hardcode → \`var(--muted-2)\`; \"Escrow #4821\" label \`#F3F6FF\` → \`var(--text)\` so both re-theme.

5. **\`91107e8\` fix(web): hero intro timing matches v6 (nav fade + word ease/stagger/duration)** — Two fixes in one file: nav \`autoAlpha 0→1\` at 3.5s delay (was missing), title words \`power3.out\` → \`power4.out\`, stagger 0.12 → 0.08, duration 1.2 → 1.0, delay 3.1 → 3.9.

### 🟡 Medium

6. **\`bdc5b1e\` feat(web): HIW actors pop in with back.out stagger at phase-0** — Seed scale 0.9 + opacity 0, then \`back.out(1.4)\` stagger 0.15 over 0.9s at phase-0. Previously a plain fade.

7. **\`1720d15\` fix(web): v6 typography scale — hero h1 reaches 200px, h2 mixin reaches 88px** — Hero h1 \`clamp(54px, 11vw, 200px)\` per hero.css. \`@mixin type-h2\` rewritten to \`clamp(40px, 6.4vw, 88px)\` matching v6 section-head h2.

8. **\`e0c7237\` fix(web): TheProblem strike-through fires instantly on line enter** — Dropped 0.35s delay on \`transform: scaleX(0→1)\` transition. Duration 1s → 1.1s to match v6 keyframe exactly.

9. **\`0f0b1d5\` fix(web): .wrap horizontal padding reaches 40px at desktop per v6** — \`--container-padding\` from \`var(--space-24)\` to \`clamp(1.5rem, 4vw, 2.5rem)\`. Fluid 24px → 40px across viewports.

### 🟢 Cleanup

10. **\`70fbd02\` chore(web): remove dead legacy tokens + rewire base/utils/mixins to v6** — Deleted legacy block from _variables.scss (--white, --black, --gray-*, --danger-red, --role-*, --section-* 8 aliases × 2 themes). Rewired _base.scss, _helpers.scss, _mixins.scss, _container.scss to read v6 tokens directly.

## Verified-no-op items

The audit flagged these but direct re-verification against v6 HTML/CSS showed no actual drift:

- **Section vertical padding**: every homepage section's \`.module.scss\` already has v6's 180/200px paddings; the \`.o-section\` 96px default was dead code (overridden everywhere).
- **Hero meta 4 → 3 cols**: v6 HTML:1300-1317 has 4 \`<div class=\"col\">\`; v6 CSS:420 uses \`repeat(4, 1fr)\`. App already matches.
- **Eyebrow letter-spacing**: every section eyebrow already uses \`.06em\`; hero chips use \`.18em\` (v6 also uses \`.18em\` for \`.hero-eyebrow\`).
- **Section breakpoints**: homepage section \`.module.scss\` files already use literal 720/820/900/960 px; only Header used 768px.

## Build + tests

- \`pnpm typecheck\` — clean
- \`pnpm test\` — 130 / 130 pass (new Footer assertions + all existing)
- \`pnpm build\` — production build passes

## Deferred (low priority, cosmetic)

- Custom cursor tracking / \`[data-cursor-hover]\` attribute (polish, not critical)
- Preloader counter rAF → GSAP (works fine; rAF is Lenis-safe)
- MagneticButton elastic return \`(1, 0.3)\` vs v6 \`(1, 0.4)\` (negligible)
- Compare dot hex case (\`#7fffa7\` vs \`#7FFFA7\` — functionally identical)