### PR TITLE
fix(web): revert hero h1 clamp to v6 canonical (56px, 10.8vw, 178px)

### DIFF
--- a/apps/web/src/features/homepage/HeroSection/HeroSection.module.scss
+++ b/apps/web/src/features/homepage/HeroSection/HeroSection.module.scss
@@ -180,7 +180,7 @@
 }
 
 .hero__title {
-  font-size: clamp(54px, 11vw, 200px);
+  font-size: clamp(56px, 10.8vw, 178px);
   line-height: 0.92;
   letter-spacing: -0.045em;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- Reverts `.hero__title` `font-size` clamp from Phase 5 C10's `clamp(54px, 11vw, 200px)` back to v6 canonical `clamp(56px, 10.8vw, 178px)` (`Blue Escrow v6.html:355`)
- Fixes the 4-line wrap regression — at wide viewports the 200px ceiling made each `.hero__word` inline-block exceed the 1240px max-width, so the browser wrapped internally and split `"The middleman"` → `"The"` / `"middleman"` and `"that cannot run."` → `"that cannot"` / `"run"`
- One-line diff, no markup or JS change, no typography drift elsewhere (section h2 mixin untouched)

## Root cause
`.hero__title` has `max-width: 1240px` and `text-wrap: balance`. Each `.hero__word` is `display: inline-block` and contains a space (`"The middleman"`, `"that cannot"`). When an inline-block's rendered width exceeds its parent block width, browsers wrap at the internal space. The 200px/11vw clamp pushed `"The middleman"` to ~1300px on ≥1818px viewports, triggering the wrap. v6's 178px ceiling keeps each word ≤ ~1150px and fits the parent.

## Test plan
- [x] `pnpm typecheck` in `apps/web/`
- [x] `pnpm test` — 130/130 pass
- [x] `pnpm build` — static generation succeeds
- [ ] Visual smoke at 1920×1080 / 1440×900 / 1024×768 / 375×667 — hero renders exactly 2 lines across all
- [ ] Entry animation still fires correctly (words lift at 3.9s, supporting rows fade in sequence)

Refs #64 (Phase 5 tracking issue). Follows up on the regression landed in #65 commit 1720d15.