### PR TITLE
feat(web): 2026 frontend modernization — CSS + a11y pass

### DIFF
--- a/apps/web/src/app/(marketing)/layout.tsx
+++ b/apps/web/src/app/(marketing)/layout.tsx
@@ -1,6 +1,7 @@
 import { LenisProvider } from '@/providers/LenisProvider';
 import { Header } from '@/components/layout/Header';
 import { Footer } from '@/components/layout/Footer';
+import { SkipLink } from '@/components/layout/SkipLink';
 import { ScrollProgressIndicator } from '@/components/ui/ScrollProgressIndicator';
 import { ClientEnhancements } from '@/components/layout/ClientEnhancements';
 
@@ -11,10 +12,13 @@ export default function MarketingLayout({
 }) {
   return (
     <LenisProvider>
+      <SkipLink />
       <ScrollProgressIndicator />
       <Header />
       <ClientEnhancements />
-      <main style={{ paddingTop: 'var(--header-height)' }}>{children}</main>
+      <main id="main-content" style={{ paddingTop: 'var(--header-height)' }}>
+        {children}
+      </main>
       <Footer />
     </LenisProvider>
   );

--- a/apps/web/src/app/(marketing)/page.test.tsx
+++ b/apps/web/src/app/(marketing)/page.test.tsx
@@ -7,7 +7,7 @@ vi.mock('@/features/homepage/ClientShell', () => ({
   ClientShell: () => <div data-section="preloader" />,
 }));
 vi.mock('@/features/homepage/HeroSection/HeroSection', () => ({
-  HeroSection: () => <header id="hero" />,
+  HeroSection: () => <section id="hero" />,
 }));
 vi.mock('@/features/homepage/TheProblem/TheProblem', () => ({
   TheProblem: () => <section id="problem" />,

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import { ThemeProvider } from '@/providers/ThemeProvider';
 import { THEME_INIT_SCRIPT } from '@/providers/theme-bootstrap';
@@ -40,6 +40,21 @@ export const metadata: Metadata = {
   title: 'Blue Escrow',
   description:
     'A decentralized escrow protocol where funds are protected by the blockchain, not promises.',
+};
+
+// Next.js 16 viewport config. colorScheme tells the browser both themes are
+// supported (lets native UI adapt); themeColor matches the active page
+// background per color-scheme preference, so the mobile browser chrome
+// (Android address bar, iOS standalone status bar) blends into the page.
+// Hex values mirror --bg-page in styles/settings/_variables.scss.
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  colorScheme: 'dark light',
+  themeColor: [
+    { media: '(prefers-color-scheme: dark)', color: '#0b1117' },
+    { media: '(prefers-color-scheme: light)', color: '#ffffff' },
+  ],
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/apps/web/src/components/layout/Footer/Footer.tsx
+++ b/apps/web/src/components/layout/Footer/Footer.tsx
@@ -50,7 +50,7 @@ const LEGAL_LINKS: FooterLink[] = [
 
 export function Footer() {
   return (
-    <footer className={styles.footer} role="contentinfo">
+    <footer className={styles.footer}>
       <div className={styles.footer__wrap}>
         <div className={styles.footer__giant} aria-hidden="true">
           Blue{' '}

--- a/apps/web/src/components/layout/SkipLink/SkipLink.module.scss
+++ b/apps/web/src/components/layout/SkipLink/SkipLink.module.scss
@@ -1,0 +1,34 @@
+@use '../../../styles/tools/mixins' as *;
+
+// WCAG 2.2 skip-to-main-content link. Hidden off-screen until focused via
+// keyboard; reveals as a pill in the top-left corner so the first Tab press
+// from the URL bar lets a keyboard user jump past the nav into the page body.
+.skip {
+  @include visually-hidden;
+  color: #fff;
+  background: var(--accent);
+  padding: 12px 20px;
+  border-radius: var(--radius-md);
+  font-family: var(--ff-mono);
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none;
+
+  &:focus-visible {
+    // Reset every visually-hidden constraint and pin the link inside viewport.
+    position: fixed;
+    inset-block-start: 12px;
+    inset-inline-start: 12px;
+    width: auto;
+    height: auto;
+    margin: 0;
+    padding: 12px 20px;
+    clip: auto;
+    clip-path: none;
+    white-space: normal;
+    overflow: visible;
+    z-index: var(--z-preloader);
+    outline: 2px solid var(--text);
+    outline-offset: 3px;
+  }
+}

--- a/apps/web/src/components/layout/SkipLink/SkipLink.test.tsx
+++ b/apps/web/src/components/layout/SkipLink/SkipLink.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { SkipLink } from './SkipLink';
+
+afterEach(cleanup);
+
+describe('SkipLink', () => {
+  it('renders as an anchor to #main-content by default', () => {
+    render(<SkipLink />);
+    const link = screen.getByRole('link', { name: /skip to main content/i });
+    expect(link.getAttribute('href')).toBe('#main-content');
+  });
+
+  it('accepts a custom targetId', () => {
+    render(<SkipLink targetId="hiw" />);
+    const link = screen.getByRole('link', { name: /skip to main content/i });
+    expect(link.getAttribute('href')).toBe('#hiw');
+  });
+
+  it('carries the skip CSS module class so visually-hidden styles apply', () => {
+    const { container } = render(<SkipLink />);
+    const link = container.querySelector('a');
+    expect(link).not.toBeNull();
+    expect(link?.className).toMatch(/skip/);
+  });
+});

--- a/apps/web/src/components/layout/SkipLink/SkipLink.tsx
+++ b/apps/web/src/components/layout/SkipLink/SkipLink.tsx
@@ -1,0 +1,13 @@
+import styles from './SkipLink.module.scss';
+
+interface SkipLinkProps {
+  targetId?: string;
+}
+
+export function SkipLink({ targetId = 'main-content' }: SkipLinkProps) {
+  return (
+    <a href={`#${targetId}`} className={styles.skip}>
+      Skip to main content
+    </a>
+  );
+}

--- a/apps/web/src/components/layout/SkipLink/index.ts
+++ b/apps/web/src/components/layout/SkipLink/index.ts
@@ -1,0 +1,1 @@
+export { SkipLink } from './SkipLink';

--- a/apps/web/src/components/layout/index.ts
+++ b/apps/web/src/components/layout/index.ts
@@ -1,2 +1,3 @@
 export { Header } from './Header';
 export { Footer } from './Footer';
+export { SkipLink } from './SkipLink';

--- a/apps/web/src/components/ui/ScrollProgressIndicator/ScrollProgressIndicator.test.tsx
+++ b/apps/web/src/components/ui/ScrollProgressIndicator/ScrollProgressIndicator.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
 import { createRef } from 'react';
 
 // Mock LenisProvider's useScrollProgress
@@ -8,6 +8,8 @@ vi.mock('@/providers/LenisProvider', () => ({
 }));
 
 import { ScrollProgressIndicator } from './ScrollProgressIndicator';
+
+afterEach(cleanup);
 
 describe('ScrollProgressIndicator', () => {
   it('renders with progressbar role and label', () => {
@@ -20,5 +22,14 @@ describe('ScrollProgressIndicator', () => {
   it('contains a bar element', () => {
     const { container } = render(<ScrollProgressIndicator />);
     expect(container.querySelector('[class*="bar"]')).not.toBeNull();
+  });
+
+  it('exposes aria-valuemin / aria-valuemax / aria-valuenow per ARIA progressbar spec', () => {
+    render(<ScrollProgressIndicator />);
+    const progressbar = screen.getByRole('progressbar');
+    expect(progressbar.getAttribute('aria-valuemin')).toBe('0');
+    expect(progressbar.getAttribute('aria-valuemax')).toBe('100');
+    // Initial value is 0 (no scroll); ticker updates it to current scroll pct
+    expect(progressbar.getAttribute('aria-valuenow')).toBe('0');
   });
 });

--- a/apps/web/src/components/ui/ScrollProgressIndicator/ScrollProgressIndicator.tsx
+++ b/apps/web/src/components/ui/ScrollProgressIndicator/ScrollProgressIndicator.tsx
@@ -6,15 +6,24 @@ import { useScrollProgress } from '@/providers/LenisProvider';
 import styles from './ScrollProgressIndicator.module.scss';
 
 export function ScrollProgressIndicator() {
+  const containerRef = useRef<HTMLDivElement>(null);
   const barRef = useRef<HTMLDivElement>(null);
   const scrollProgressRef = useScrollProgress();
 
   useEffect(() => {
+    const container = containerRef.current;
     const bar = barRef.current;
-    if (!bar) return;
+    if (!container || !bar) return;
 
+    let lastPct = -1;
     const tickerCallback = () => {
-      bar.style.transform = `scaleX(${scrollProgressRef.current})`;
+      const progress = scrollProgressRef.current;
+      bar.style.transform = `scaleX(${progress})`;
+      const pct = Math.round(progress * 100);
+      if (pct !== lastPct) {
+        container.setAttribute('aria-valuenow', String(pct));
+        lastPct = pct;
+      }
     };
 
     gsap.ticker.add(tickerCallback);
@@ -24,7 +33,15 @@ export function ScrollProgressIndicator() {
   }, [scrollProgressRef]);
 
   return (
-    <div className={styles.progress} role="progressbar" aria-label="Scroll progress">
+    <div
+      ref={containerRef}
+      className={styles.progress}
+      role="progressbar"
+      aria-label="Scroll progress"
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={0}
+    >
       <div ref={barRef} className={styles.progress__bar} />
     </div>
   );

--- a/apps/web/src/features/homepage/Compare/Compare.module.scss
+++ b/apps/web/src/features/homepage/Compare/Compare.module.scss
@@ -10,7 +10,7 @@
   background:
     radial-gradient(
       ellipse 60% 80% at 0% 50%,
-      rgba(0, 145, 255, 0.5),
+      color-mix(in srgb, var(--blue-vivid) 50%, transparent),
       transparent 60%
     ),
     radial-gradient(
@@ -30,7 +30,7 @@
     background:
       radial-gradient(
         ellipse 60% 80% at 0% 50%,
-        rgba(0, 145, 255, 0.55),
+        color-mix(in srgb, var(--blue-vivid) 55%, transparent),
         transparent 60%
       ),
       radial-gradient(

--- a/apps/web/src/features/homepage/HeroSection/HeroSection.module.scss
+++ b/apps/web/src/features/homepage/HeroSection/HeroSection.module.scss
@@ -14,7 +14,7 @@
 
 .hero {
   position: relative;
-  min-height: 100vh;
+  min-height: 100dvh;
   overflow: hidden;
   isolation: isolate;
   display: flex;

--- a/apps/web/src/features/homepage/HeroSection/HeroSection.module.scss
+++ b/apps/web/src/features/homepage/HeroSection/HeroSection.module.scss
@@ -268,13 +268,13 @@
   background: var(--blue-primary);
   color: #fff;
   box-shadow:
-    0 10px 30px -10px rgba(0, 102, 255, 0.6),
+    0 10px 30px -10px color-mix(in srgb, var(--blue-primary) 60%, transparent),
     inset 0 1px 0 rgba(255, 255, 255, 0.2);
 
   &:hover {
     background: var(--blue-hover);
     box-shadow:
-      0 14px 40px -10px rgba(0, 102, 255, 0.8),
+      0 14px 40px -10px color-mix(in srgb, var(--blue-primary) 80%, transparent),
       inset 0 1px 0 rgba(255, 255, 255, 0.2);
   }
 }

--- a/apps/web/src/features/homepage/HeroSection/HeroSection.test.tsx
+++ b/apps/web/src/features/homepage/HeroSection/HeroSection.test.tsx
@@ -68,11 +68,11 @@ describe('HeroSection (v6)', () => {
     expect(container.textContent?.match(/Deal #4821 signed/g)?.length).toBe(4);
   });
 
-  it('renders as <header id="hero"> with accessible label', () => {
+  it('renders as <section id="hero"> with accessible label', () => {
     const { container } = render(<HeroSection />);
-    const header = container.querySelector('header');
-    expect(header?.id).toBe('hero');
-    expect(header?.getAttribute('aria-label')).toBe(
+    const section = container.querySelector('section#hero');
+    expect(section).not.toBeNull();
+    expect(section?.getAttribute('aria-label')).toBe(
       'Decentralized escrow protocol',
     );
   });

--- a/apps/web/src/features/homepage/HeroSection/HeroSection.tsx
+++ b/apps/web/src/features/homepage/HeroSection/HeroSection.tsx
@@ -88,7 +88,7 @@ function renderTicker(prefix: string) {
 
 export function HeroSection() {
   return (
-    <header
+    <section
       className={styles.hero}
       id="hero"
       aria-label="Decentralized escrow protocol"
@@ -216,6 +216,6 @@ export function HeroSection() {
           </div>
         </div>
       </HeroAnimations>
-    </header>
+    </section>
   );
 }

--- a/apps/web/src/styles/elements/_base.scss
+++ b/apps/web/src/styles/elements/_base.scss
@@ -4,6 +4,9 @@
 // correctly on any unstyled element.
 // ============================================================================
 
+@use '../settings/typography' as *;
+@use '../tools/mixins' as *;
+
 body {
   background-color: var(--bg-page);
   color: var(--text);

--- a/apps/web/src/styles/elements/_base.scss
+++ b/apps/web/src/styles/elements/_base.scss
@@ -2,120 +2,123 @@
 // BASE ELEMENT STYLES — Bare HTML elements styled with v6 theme tokens.
 // Every color reads from :root[data-theme] so both dark/light themes paint
 // correctly on any unstyled element.
+// Wrapped in @layer elements.
 // ============================================================================
 
 @use '../settings/typography' as *;
 @use '../tools/mixins' as *;
 
-body {
-  background-color: var(--bg-page);
-  color: var(--text);
-  font-family: var(--ff-sans);
-  overflow-x: hidden;
-  @include type-body;
-}
-
-// --- Headings ---
-
-h1 {
-  @include type-h1;
-  color: var(--text);
-}
-
-h2 {
-  @include type-h2;
-  color: var(--text);
-}
-
-h3 {
-  @include type-h3;
-  color: var(--text);
-}
-
-h4 {
-  @include type-h4;
-}
-
-h5 {
-  @include type-h5;
-}
-
-h6 {
-  @include type-caption;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-// --- Paragraphs ---
-
-p {
-  color: var(--text);
-}
-
-// --- Links ---
-
-a {
-  color: var(--accent);
-  text-decoration: none;
-  transition: color var(--transition-fast);
-
-  &:hover {
-    color: var(--blue-hover);
+@layer elements {
+  body {
+    background-color: var(--bg-page);
+    color: var(--text);
+    font-family: var(--ff-sans);
+    overflow-x: hidden;
+    @include type-body;
   }
-}
 
-// --- Inline Code ---
+  // --- Headings ---
 
-code {
-  font-family: var(--ff-mono);
-  font-size: 0.875em;
-  padding: 0.125em 0.375em;
-  background: var(--bg-surface);
-  border-radius: var(--radius-sm);
-}
+  h1 {
+    @include type-h1;
+    color: var(--text);
+  }
 
-// --- Code Blocks ---
+  h2 {
+    @include type-h2;
+    color: var(--text);
+  }
 
-pre {
-  font-family: var(--ff-mono);
-  font-size: 0.875rem;
-  line-height: 1.6;
-  padding: var(--space-16) var(--space-24);
-  background: var(--bg-surface);
-  border-radius: var(--radius-md);
-  overflow-x: auto;
+  h3 {
+    @include type-h3;
+    color: var(--text);
+  }
+
+  h4 {
+    @include type-h4;
+  }
+
+  h5 {
+    @include type-h5;
+  }
+
+  h6 {
+    @include type-caption;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  // --- Paragraphs ---
+
+  p {
+    color: var(--text);
+  }
+
+  // --- Links ---
+
+  a {
+    color: var(--accent);
+    text-decoration: none;
+    transition: color var(--transition-fast);
+
+    &:hover {
+      color: var(--blue-hover);
+    }
+  }
+
+  // --- Inline Code ---
 
   code {
-    padding: 0;
-    background: none;
+    font-family: var(--ff-mono);
+    font-size: 0.875em;
+    padding: 0.125em 0.375em;
+    background: var(--bg-surface);
+    border-radius: var(--radius-sm);
   }
-}
 
-// --- Horizontal Rule ---
+  // --- Code Blocks ---
 
-hr {
-  border: none;
-  border-block-start: 1px solid var(--border);
-  margin-block: var(--space-32);
-}
+  pre {
+    font-family: var(--ff-mono);
+    font-size: 0.875rem;
+    line-height: 1.6;
+    padding: var(--space-16) var(--space-24);
+    background: var(--bg-surface);
+    border-radius: var(--radius-md);
+    overflow-x: auto;
 
-// --- Strong ---
+    code {
+      padding: 0;
+      background: none;
+    }
+  }
 
-strong,
-b {
-  font-weight: 600;
-}
+  // --- Horizontal Rule ---
 
-// --- Selection ---
+  hr {
+    border: none;
+    border-block-start: 1px solid var(--border);
+    margin-block: var(--space-32);
+  }
 
-::selection {
-  background-color: var(--accent);
-  color: #fff;
-}
+  // --- Strong ---
 
-// --- Custom Scrollbar (body) ---
+  strong,
+  b {
+    font-weight: 600;
+  }
 
-body {
-  @include custom-scrollbar(6px, transparent, var(--border));
+  // --- Selection ---
+
+  ::selection {
+    background-color: var(--accent);
+    color: #fff;
+  }
+
+  // --- Custom Scrollbar (body) ---
+
+  body {
+    @include custom-scrollbar(6px, transparent, var(--border));
+  }
 }

--- a/apps/web/src/styles/generic/_reset.scss
+++ b/apps/web/src/styles/generic/_reset.scss
@@ -1,132 +1,136 @@
 // ============================================================================
 // MODERN CSS RESET (2026)
 // Hybrid: Josh Comeau + Andy Bell + modern additions
+// Wrapped in @layer reset — lowest normal-priority layer, highest !important
+// (so reduced-motion kill-switch beats component overrides).
 // ============================================================================
 
-// --- Box Sizing ---
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-}
-
-// --- Remove Default Margins and Padding ---
-* {
-  margin: 0;
-  padding: 0;
-}
-
-// --- Smooth Scrolling (respecting user preference) ---
-html {
-  scroll-behavior: smooth;
-  -webkit-text-size-adjust: 100%;
-  text-size-adjust: 100%;
-  overflow-x: clip;
-
-  @media (prefers-reduced-motion: reduce) {
-    scroll-behavior: auto;
-  }
-}
-
-// --- Body Defaults ---
-body {
-  min-height: 100dvh;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  text-rendering: optimizeLegibility;
-}
-
-// --- Typography Wrapping ---
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  text-wrap: balance;
-}
-
-p,
-li,
-figcaption {
-  text-wrap: pretty;
-  max-inline-size: 75ch;
-}
-
-// --- Media Defaults ---
-img,
-picture,
-video,
-canvas,
-svg {
-  display: block;
-  max-width: 100%;
-}
-
-img {
-  height: auto;
-  font-style: italic;
-}
-
-// --- Form Element Font Inheritance ---
-input,
-button,
-textarea,
-select {
-  font: inherit;
-  color: inherit;
-}
-
-// --- Button Reset ---
-button {
-  cursor: pointer;
-  background: none;
-  border: none;
-}
-
-// --- Link Reset ---
-a {
-  color: inherit;
-  text-decoration: inherit;
-}
-
-// --- List Reset ---
-ul,
-ol {
-  list-style: none;
-}
-
-// --- Table Reset ---
-table {
-  border-collapse: collapse;
-  border-spacing: 0;
-}
-
-// --- Focus Visible ---
-:focus-visible {
-  outline: 2px solid var(--blue-vivid);
-  outline-offset: 2px;
-}
-
-:focus:not(:focus-visible) {
-  outline: none;
-}
-
-// --- Reduced Motion: kill all animations ---
-@media (prefers-reduced-motion: reduce) {
+@layer reset {
+  // --- Box Sizing ---
   *,
   *::before,
   *::after {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
-    scroll-behavior: auto !important;
+    box-sizing: border-box;
   }
-}
 
-// SplitText word wrappers — force GPU compositing for clean antialiasing
-h1 > div, h2 > div, h3 > div {
-  backface-visibility: hidden;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  // --- Remove Default Margins and Padding ---
+  * {
+    margin: 0;
+    padding: 0;
+  }
+
+  // --- Smooth Scrolling (respecting user preference) ---
+  html {
+    scroll-behavior: smooth;
+    -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
+    overflow-x: clip;
+
+    @media (prefers-reduced-motion: reduce) {
+      scroll-behavior: auto;
+    }
+  }
+
+  // --- Body Defaults ---
+  body {
+    min-height: 100dvh;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
+  }
+
+  // --- Typography Wrapping ---
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    text-wrap: balance;
+  }
+
+  p,
+  li,
+  figcaption {
+    text-wrap: pretty;
+    max-inline-size: 75ch;
+  }
+
+  // --- Media Defaults ---
+  img,
+  picture,
+  video,
+  canvas,
+  svg {
+    display: block;
+    max-width: 100%;
+  }
+
+  img {
+    height: auto;
+    font-style: italic;
+  }
+
+  // --- Form Element Font Inheritance ---
+  input,
+  button,
+  textarea,
+  select {
+    font: inherit;
+    color: inherit;
+  }
+
+  // --- Button Reset ---
+  button {
+    cursor: pointer;
+    background: none;
+    border: none;
+  }
+
+  // --- Link Reset ---
+  a {
+    color: inherit;
+    text-decoration: inherit;
+  }
+
+  // --- List Reset ---
+  ul,
+  ol {
+    list-style: none;
+  }
+
+  // --- Table Reset ---
+  table {
+    border-collapse: collapse;
+    border-spacing: 0;
+  }
+
+  // --- Focus Visible ---
+  :focus-visible {
+    outline: 2px solid var(--blue-vivid);
+    outline-offset: 2px;
+  }
+
+  :focus:not(:focus-visible) {
+    outline: none;
+  }
+
+  // --- Reduced Motion: kill all animations ---
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
+  }
+
+  // SplitText word wrappers — force GPU compositing for clean antialiasing
+  h1 > div, h2 > div, h3 > div {
+    backface-visibility: hidden;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
 }

--- a/apps/web/src/styles/globals.scss
+++ b/apps/web/src/styles/globals.scss
@@ -1,20 +1,24 @@
 // ITCSS — Import order matters (generic → specific)
+// Migrated from @import (deprecated, removed in Dart Sass 3.0 ~Oct 2026)
+// to @use (explicit scoping, one-load guarantee).
 
-// Layer 1: Settings — Design tokens
-@import 'settings/variables';
-@import 'settings/typography';
+// Layer 1: Settings — Design tokens (CSS vars + SCSS $bp-*)
+@use 'settings/variables';
 
-// Layer 2: Tools — Mixins and functions
-@import 'tools/mixins';
+// Layer 1b: Settings — Typography mixins
+@use 'settings/typography';
 
-// Layer 3: Generic — Resets and normalize
-@import 'generic/reset';
+// Layer 2: Tools — Responsive + visual mixins
+@use 'tools/mixins';
+
+// Layer 3: Generic — Modern CSS reset
+@use 'generic/reset';
 
 // Layer 4: Elements — Bare HTML element styles
-@import 'elements/base';
+@use 'elements/base';
 
 // Layer 5: Objects — Layout patterns
-@import 'objects/container';
+@use 'objects/container';
 
 // Layer 7: Utilities — Helper classes
-@import 'utilities/helpers';
+@use 'utilities/helpers';

--- a/apps/web/src/styles/globals.scss
+++ b/apps/web/src/styles/globals.scss
@@ -1,24 +1,27 @@
 // ITCSS — Import order matters (generic → specific)
 // Migrated from @import (deprecated, removed in Dart Sass 3.0 ~Oct 2026)
 // to @use (explicit scoping, one-load guarantee).
+//
+// The @layer cascade order is declared at the top of settings/_variables.scss
+// so it runs before any layered content is emitted.
 
-// Layer 1: Settings — Design tokens (CSS vars + SCSS $bp-*)
+// Layer 1: Settings — Design tokens + @layer cascade declaration.
 @use 'settings/variables';
 
-// Layer 1b: Settings — Typography mixins
+// Layer 1b: Settings — Typography mixins (no CSS output).
 @use 'settings/typography';
 
-// Layer 2: Tools — Responsive + visual mixins
+// Layer 2: Tools — Responsive + visual mixins (no CSS output).
 @use 'tools/mixins';
 
-// Layer 3: Generic — Modern CSS reset
+// Layer 3: Generic — Modern CSS reset (wrapped in @layer reset).
 @use 'generic/reset';
 
-// Layer 4: Elements — Bare HTML element styles
+// Layer 4: Elements — Bare HTML element styles (wrapped in @layer elements).
 @use 'elements/base';
 
-// Layer 5: Objects — Layout patterns
+// Layer 5: Objects — Layout patterns (wrapped in @layer objects).
 @use 'objects/container';
 
-// Layer 7: Utilities — Helper classes
+// Layer 7: Utilities — Helper classes (wrapped in @layer utilities).
 @use 'utilities/helpers';

--- a/apps/web/src/styles/objects/_container.scss
+++ b/apps/web/src/styles/objects/_container.scss
@@ -1,95 +1,98 @@
 // ============================================================================
 // LAYOUT OBJECTS — Containers, sections, grids
+// Wrapped in @layer objects.
 // ============================================================================
 
 @use '../settings/variables' as *;
 @use '../tools/mixins' as *;
 
-// --- Container ---
+@layer objects {
+  // --- Container ---
 
-.o-container {
-  width: 100%;
-  max-width: var(--container-max);
-  margin-inline: auto;
-  padding-inline: var(--container-padding);
-}
+  .o-container {
+    width: 100%;
+    max-width: var(--container-max);
+    margin-inline: auto;
+    padding-inline: var(--container-padding);
+  }
 
-.o-container--narrow {
-  max-width: 960px;
-}
+  .o-container--narrow {
+    max-width: 960px;
+  }
 
-.o-container--wide {
-  max-width: 1600px;
-}
+  .o-container--wide {
+    max-width: 1600px;
+  }
 
-// --- Section ---
+  // --- Section ---
 
-.o-section {
-  position: relative;
-  z-index: 2;
-  // Padding intentionally omitted — every homepage section ships its own
-  // vertical rhythm in its .module.scss to match v6's bespoke per-section
-  // paddings (160-200px). .o-section is a positioning anchor only.
-}
+  .o-section {
+    position: relative;
+    z-index: 2;
+    // Padding intentionally omitted — every homepage section ships its own
+    // vertical rhythm in its .module.scss to match v6's bespoke per-section
+    // paddings (160-200px). .o-section is a positioning anchor only.
+  }
 
-// --- Grid ---
+  // --- Grid ---
 
-.o-grid {
-  display: grid;
-  gap: var(--space-24);
-}
+  .o-grid {
+    display: grid;
+    gap: var(--space-24);
+  }
 
-.o-grid--2 {
-  grid-template-columns: 1fr;
+  .o-grid--2 {
+    grid-template-columns: 1fr;
 
-  @include responsive($bp-tablet) {
+    @include responsive($bp-tablet) {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+
+  .o-grid--3 {
+    grid-template-columns: 1fr;
+
+    @include responsive($bp-tablet) {
+      grid-template-columns: repeat(2, 1fr);
+    }
+
+    @include responsive($bp-desktop) {
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+
+  .o-grid--4 {
     grid-template-columns: repeat(2, 1fr);
-  }
-}
 
-.o-grid--3 {
-  grid-template-columns: 1fr;
+    @include responsive($bp-tablet) {
+      grid-template-columns: repeat(3, 1fr);
+    }
 
-  @include responsive($bp-tablet) {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  @include responsive($bp-desktop) {
-    grid-template-columns: repeat(3, 1fr);
-  }
-}
-
-.o-grid--4 {
-  grid-template-columns: repeat(2, 1fr);
-
-  @include responsive($bp-tablet) {
-    grid-template-columns: repeat(3, 1fr);
+    @include responsive($bp-desktop) {
+      grid-template-columns: repeat(4, 1fr);
+    }
   }
 
-  @include responsive($bp-desktop) {
-    grid-template-columns: repeat(4, 1fr);
+  // --- Stack (vertical spacing) ---
+
+  .o-stack {
+    display: flex;
+    flex-direction: column;
   }
-}
 
-// --- Stack (vertical spacing) ---
+  .o-stack--sm {
+    gap: var(--space-8);
+  }
 
-.o-stack {
-  display: flex;
-  flex-direction: column;
-}
+  .o-stack--md {
+    gap: var(--space-16);
+  }
 
-.o-stack--sm {
-  gap: var(--space-8);
-}
+  .o-stack--lg {
+    gap: var(--space-32);
+  }
 
-.o-stack--md {
-  gap: var(--space-16);
-}
-
-.o-stack--lg {
-  gap: var(--space-32);
-}
-
-.o-stack--xl {
-  gap: var(--space-64);
+  .o-stack--xl {
+    gap: var(--space-64);
+  }
 }

--- a/apps/web/src/styles/objects/_container.scss
+++ b/apps/web/src/styles/objects/_container.scss
@@ -2,6 +2,9 @@
 // LAYOUT OBJECTS — Containers, sections, grids
 // ============================================================================
 
+@use '../settings/variables' as *;
+@use '../tools/mixins' as *;
+
 // --- Container ---
 
 .o-container {

--- a/apps/web/src/styles/settings/_variables.scss
+++ b/apps/web/src/styles/settings/_variables.scss
@@ -112,6 +112,8 @@ $bp-section: 900px;
 
 :root,
 :root[data-theme='dark'] {
+  color-scheme: dark;
+
   --bg-page:       #0b1117;
   --bg-surface:    #111b2a;
   --bg-tint:       #0d2244;
@@ -140,6 +142,8 @@ $bp-section: 900px;
 // ----------------------------------------------------------------------------
 
 :root[data-theme='light'] {
+  color-scheme: light;
+
   --bg-page:       #ffffff;
   --bg-surface:    #f5f8fc;
   --bg-tint:       #e6f1ff;

--- a/apps/web/src/styles/settings/_variables.scss
+++ b/apps/web/src/styles/settings/_variables.scss
@@ -137,14 +137,14 @@ $bp-section: 900px;
   --border-strong: #2a3b5c;
 
   --accent:        var(--blue-vivid);
-  --accent-soft:   rgba(0, 145, 255, 0.12);
+  --accent-soft:   color-mix(in srgb, var(--blue-vivid) 12%, transparent);
 
   --on-card:       rgba(255, 255, 255, 0.06);
   --on-border:     rgba(255, 255, 255, 0.12);
 
   --hero-grad:
-    radial-gradient(ellipse 60% 50% at 50% 30%, rgba(0, 145, 255, 0.35), transparent 70%),
-    radial-gradient(ellipse 80% 60% at 80% 90%, rgba(0, 102, 255, 0.25), transparent 70%),
+    radial-gradient(ellipse 60% 50% at 50% 30%, color-mix(in srgb, var(--blue-vivid) 35%, transparent), transparent 70%),
+    radial-gradient(ellipse 80% 60% at 80% 90%, color-mix(in srgb, var(--blue-primary) 25%, transparent), transparent 70%),
     linear-gradient(180deg, #001b4d 0%, #0b1117 70%);
   --blue-band:
     linear-gradient(135deg, var(--blue-primary) 0%, var(--blue-vivid) 100%);
@@ -167,14 +167,14 @@ $bp-section: 900px;
   --border-strong: #c9d2de;
 
   --accent:        var(--blue-primary);
-  --accent-soft:   rgba(0, 102, 255, 0.08);
+  --accent-soft:   color-mix(in srgb, var(--blue-primary) 8%, transparent);
 
   --on-card:       rgba(0, 27, 77, 0.04);
   --on-border:     rgba(0, 27, 77, 0.10);
 
   --hero-grad:
-    radial-gradient(ellipse 70% 60% at 50% 30%, rgba(0, 145, 255, 0.18), transparent 70%),
-    radial-gradient(ellipse 80% 60% at 80% 90%, rgba(0, 102, 255, 0.10), transparent 70%),
+    radial-gradient(ellipse 70% 60% at 50% 30%, color-mix(in srgb, var(--blue-vivid) 18%, transparent), transparent 70%),
+    radial-gradient(ellipse 80% 60% at 80% 90%, color-mix(in srgb, var(--blue-primary) 10%, transparent), transparent 70%),
     linear-gradient(180deg, #e6f1ff 0%, #ffffff 70%);
   --blue-band:
     linear-gradient(135deg, var(--blue-primary) 0%, var(--blue-vivid) 100%);

--- a/apps/web/src/styles/settings/_variables.scss
+++ b/apps/web/src/styles/settings/_variables.scss
@@ -1,4 +1,17 @@
 // ============================================================================
+// @layer cascade — declared here (first file @used by globals.scss) so the
+// order locks BEFORE any layered content is emitted by downstream partials.
+//
+// Normal priority:    [unlayered modules] > utilities > components > objects > elements > reset
+// !important priority (reversed): reset > elements > objects > components > utilities > [unlayered]
+//
+// The reversed !important means reset's reduced-motion kill-switch overrides
+// component animations, and .u-* utilities still beat unlayered CSS Module
+// rules via their explicit !important.
+// ============================================================================
+@layer reset, elements, objects, components, utilities;
+
+// ============================================================================
 // SCSS VARIABLES — Only for breakpoints (CSS vars cannot be used in @media)
 // ============================================================================
 

--- a/apps/web/src/styles/utilities/_helpers.scss
+++ b/apps/web/src/styles/utilities/_helpers.scss
@@ -81,8 +81,8 @@
 // --- Full Bleed (break out of container) ---
 
 .u-full-bleed {
-  width: 100vw;
-  margin-inline-start: calc(50% - 50vw);
+  width: 100svw;
+  margin-inline-start: calc(50% - 50svw);
 }
 
 // --- Spacing Utilities (margin-block-end) ---

--- a/apps/web/src/styles/utilities/_helpers.scss
+++ b/apps/web/src/styles/utilities/_helpers.scss
@@ -1,96 +1,100 @@
 // ============================================================================
 // UTILITY CLASSES — High-specificity overrides (ITCSS Layer 7)
+// Wrapped in @layer utilities — highest normal-priority layer.
+// !important preserved so utilities beat unlayered CSS Modules.
 // ============================================================================
 
-// --- Accessibility ---
+@layer utilities {
+  // --- Accessibility ---
 
-.u-visually-hidden {
-  position: absolute !important;
-  width: 1px !important;
-  height: 1px !important;
-  padding: 0 !important;
-  margin: -1px !important;
-  overflow: hidden !important;
-  clip: rect(0, 0, 0, 0) !important;
-  clip-path: inset(50%) !important;
-  white-space: nowrap !important;
-  border: 0 !important;
-}
-
-// --- Text Alignment ---
-
-.u-text-center {
-  text-align: center !important;
-}
-
-.u-text-start {
-  text-align: start !important;
-}
-
-.u-text-end {
-  text-align: end !important;
-}
-
-// --- Text Color Overrides ---
-
-.u-text-muted {
-  color: var(--text-muted) !important;
-}
-
-.u-text-heading {
-  color: var(--accent) !important;
-}
-
-// --- Display ---
-
-.u-block {
-  display: block !important;
-}
-
-.u-inline-block {
-  display: inline-block !important;
-}
-
-.u-flex {
-  display: flex !important;
-}
-
-.u-grid {
-  display: grid !important;
-}
-
-.u-hidden {
-  display: none !important;
-}
-
-// --- Reduced Motion ---
-
-.u-reduced-motion {
-  @media (prefers-reduced-motion: reduce) {
-    animation: none !important;
-    transition: none !important;
+  .u-visually-hidden {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    padding: 0 !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    clip: rect(0, 0, 0, 0) !important;
+    clip-path: inset(50%) !important;
+    white-space: nowrap !important;
+    border: 0 !important;
   }
+
+  // --- Text Alignment ---
+
+  .u-text-center {
+    text-align: center !important;
+  }
+
+  .u-text-start {
+    text-align: start !important;
+  }
+
+  .u-text-end {
+    text-align: end !important;
+  }
+
+  // --- Text Color Overrides ---
+
+  .u-text-muted {
+    color: var(--text-muted) !important;
+  }
+
+  .u-text-heading {
+    color: var(--accent) !important;
+  }
+
+  // --- Display ---
+
+  .u-block {
+    display: block !important;
+  }
+
+  .u-inline-block {
+    display: inline-block !important;
+  }
+
+  .u-flex {
+    display: flex !important;
+  }
+
+  .u-grid {
+    display: grid !important;
+  }
+
+  .u-hidden {
+    display: none !important;
+  }
+
+  // --- Reduced Motion ---
+
+  .u-reduced-motion {
+    @media (prefers-reduced-motion: reduce) {
+      animation: none !important;
+      transition: none !important;
+    }
+  }
+
+  // --- No Scroll (for modal/overlay states) ---
+
+  .u-no-scroll {
+    overflow: hidden !important;
+  }
+
+  // --- Full Bleed (break out of container) ---
+
+  .u-full-bleed {
+    width: 100svw;
+    margin-inline-start: calc(50% - 50svw);
+  }
+
+  // --- Spacing Utilities (margin-block-end) ---
+
+  .u-mb-0 { margin-block-end: 0 !important; }
+  .u-mb-8 { margin-block-end: var(--space-8) !important; }
+  .u-mb-16 { margin-block-end: var(--space-16) !important; }
+  .u-mb-24 { margin-block-end: var(--space-24) !important; }
+  .u-mb-32 { margin-block-end: var(--space-32) !important; }
+  .u-mb-48 { margin-block-end: var(--space-48) !important; }
+  .u-mb-64 { margin-block-end: var(--space-64) !important; }
 }
-
-// --- No Scroll (for modal/overlay states) ---
-
-.u-no-scroll {
-  overflow: hidden !important;
-}
-
-// --- Full Bleed (break out of container) ---
-
-.u-full-bleed {
-  width: 100svw;
-  margin-inline-start: calc(50% - 50svw);
-}
-
-// --- Spacing Utilities (margin-block-end) ---
-
-.u-mb-0 { margin-block-end: 0 !important; }
-.u-mb-8 { margin-block-end: var(--space-8) !important; }
-.u-mb-16 { margin-block-end: var(--space-16) !important; }
-.u-mb-24 { margin-block-end: var(--space-24) !important; }
-.u-mb-32 { margin-block-end: var(--space-32) !important; }
-.u-mb-48 { margin-block-end: var(--space-48) !important; }
-.u-mb-64 { margin-block-end: var(--space-64) !important; }


### PR DESCRIPTION
Parent epic: #67 · Closes #68, #69

## Summary
- **9 commits across 2 tracks** turning a 3-agent audit + 2026 web-standards research into surgical modernizations
- **No visual regression** — every commit passes `pnpm typecheck && pnpm test && pnpm build`
- **134/134 tests** passing (130 prior + 4 new a11y assertions)
- Each commit is independently reversible; commit order lets reviewers bisect if anything drifts

## Track A — CSS modernization (5 commits)

| # | SHA | Change |
|---|---|---|
| A1 | `5b5c1d3` | `refactor(web): migrate globals.scss from @import to @use` — prep for Dart Sass 3.0 removal (~Oct 2026). Partials that consume other partials (`_base.scss`, `_container.scss`) now declare their own `@use`. |
| A2 | `8fe6277` | `fix(web): hero min-height uses 100dvh + u-full-bleed uses 100svw` — eliminates iOS Safari toolbar jank; matches `100dvh` already used on body. |
| A3 | `3da13ee` | `feat(web): declare color-scheme per theme on :root` — native scrollbars, form controls, date pickers now follow `[data-theme]` without JS. |
| A4 | `00fc061` | `feat(web): introduce CSS cascade layers (reset, elements, objects, components, utilities)` — locks specificity order; reset's reduced-motion `!important` beats component overrides (reversed `!important` cascade). |
| A5 | `a642245` | `refactor(web): adopt color-mix() for brand-tint overlays` — 9 `rgba()` hardcodes replaced with `color-mix(in srgb, var(--blue-vivid\|primary) X%, transparent)` so overlays track the token. |

## Track B — A11y + semantics (4 commits)

| # | SHA | Change |
|---|---|---|
| B1 | `8e4d653` | `feat(web): add viewport export with themeColor per color-scheme` — Android/iOS browser chrome matches page background per theme. |
| B2 | `161484b` | `feat(web): add skip-to-main-content link` — new `SkipLink` component reuses `@mixin visually-hidden`, reveals on `:focus-visible`. WCAG 2.2 AA requirement. |
| B3 | `c359a16` | `fix(web): ScrollProgressIndicator exposes aria-value + remove redundant footer role` — `aria-valuemin/max/now` per ARIA progressbar spec; `<footer>`'s implicit `contentinfo` role kept (was redundant explicit role). |
| B4 | `db6e71d` | `refactor(web): HeroSection uses <section> landmark, not <header>` — removes duplicate header landmark (`<Header>` is the sole top-level header). |

## Research & audit methodology
- 3 parallel `Explore` agents (HTML semantics + CSS/SCSS architecture + responsive/a11y/perf)
- 2 `WebSearch` queries against authoritative 2026 sources (sass-lang.com deprecation, WCAG 2.2, MDN CSS WG specs)
- Every CRITICAL/HIGH agent finding verified against actual `file:line` before acting (Phase 5 taught us agents misread)
- False positives rejected: missing viewport meta (Next.js auto-injects), `data-theme='dark'` hardcoded (`suppressHydrationWarning` + pre-hydration script handle it), Compare table rowcount (optional per ARIA 1.2)

## Deferred to follow-up PRDs
Container queries rollout · View Transitions API for theme toggle · `@starting-style` entry animations · `contain: layout style paint` on heavy sections · Preloader CLS fix · RTL pass (remaining `top/left/right/bottom` → logical properties) · Compare native `<table>` migration · Lenis `lagSmoothing` tuning

## Test plan
- [x] `pnpm typecheck` ✓
- [x] `pnpm test` — 134/134 pass (+3 SkipLink, +1 ScrollProgressIndicator aria)
- [x] `pnpm build` ✓
- [ ] Visual smoke: resize 1920 → 1440 → 1024 → 820 → 768 → 720 → 560 → 375; toggle `prefers-color-scheme` and `prefers-reduced-motion` in DevTools; Tab from URL bar — first focus must be the Skip link
- [ ] iOS Safari simulator — hero fills dynamic viewport without jumping on toolbar collapse
- [ ] Run axe DevTools / Lighthouse a11y — target score ≥ 95

## Standards anchor
- [Sass: @import is deprecated](https://sass-lang.com/blog/import-is-deprecated/)
- [WCAG 2.2 AA](https://www.w3.org/TR/WCAG22/)
- `@layer`, `:has()`, `color-mix()`, `dvh/svh/lvh`, `text-wrap: balance`, `:focus-visible` — all Baseline 2024+