### PR TITLE
fix(web): responsive giant wordmarks + HIW polish (container queries)

### DIFF
--- a/apps/web/src/components/layout/Footer/Footer.module.scss
+++ b/apps/web/src/components/layout/Footer/Footer.module.scss
@@ -19,11 +19,20 @@
   max-width: var(--container-max);
   margin-inline: auto;
   padding-inline: var(--container-padding);
+  // Establishes a size-query context so .footer__giant's font-size can
+  // track this wrap's actual inline width (container_max − padding),
+  // not the viewport. Eliminates the overflow/clip at 375-900px viewports
+  // where viewport-based clamp outran the padded container width.
+  container-type: inline-size;
 }
 
 // Giant wordmark — "Blue" outlined via text-stroke, "Escrow." filled italic
 .footer__giant {
-  font-size: clamp(80px, 20vw, 300px);
+  // cqw scales with .footer__wrap (≈ viewport − container padding).
+  // Math: 6em per "Blue Escrow." → at 375px viewport (327px wrap),
+  // 16cqw = 52.3 → text 314 < 327 ✓. At 1440px viewport (1360px wrap),
+  // 16cqw = 218 → text 1308 < 1360 ✓. Floor 44 keeps tiny viewports clean.
+  font-size: clamp(44px, 16cqw, 300px);
   line-height: 0.85;
   letter-spacing: -0.055em;
   font-weight: 500;

--- a/apps/web/src/features/homepage/CtaSection/CtaSection.module.scss
+++ b/apps/web/src/features/homepage/CtaSection/CtaSection.module.scss
@@ -57,6 +57,11 @@
   text-wrap: balance;
   max-width: 14ch;
   color: var(--text);
+  // Belt-and-suspenders: text-wrap: balance may pick an unbalanced
+  // break at some widths; overflow-wrap: anywhere lets a single word
+  // break if it ever exceeds max-width (defensive; no known trigger
+  // with current copy "Trade like you trust the code, not the person.").
+  overflow-wrap: anywhere;
 }
 
 .closing__emphasis {

--- a/apps/web/src/features/homepage/HowItWorks/HowItWorks.module.scss
+++ b/apps/web/src/features/homepage/HowItWorks/HowItWorks.module.scss
@@ -20,22 +20,19 @@
 }
 
 .hiw__intro {
-  padding: 140px 0 80px;
-
-  @media (max-width: 720px) {
-    padding: 100px 0 60px;
-  }
+  // Fluid vertical rhythm — no 720px step. Floor = 100/60 (matches
+  // the old mobile fallback), ceiling = 140/80 (matches old desktop).
+  padding-block-start: clamp(100px, 10vw, 140px);
+  padding-block-end: clamp(60px, 6vw, 80px);
 }
 
 .hiw__wrap {
   width: 100%;
   max-width: 1440px;
   margin: 0 auto;
-  padding: 0 40px;
-
-  @media (max-width: 720px) {
-    padding: 0 24px;
-  }
+  // Mirror --container-padding (clamp(1.5rem, 4vw, 2.5rem)) — same tokens
+  // used by .o-container, eliminating the 720px step.
+  padding-inline: clamp(1.5rem, 4vw, 2.5rem);
 }
 
 .hiw__head {
@@ -95,24 +92,23 @@
 }
 
 .hiw__stage {
-  padding: 0 40px;
-
-  @media (max-width: 720px) {
-    padding: 0 20px;
-  }
+  // Same fluid rule as .hiw__wrap — 20px min matches the old mobile
+  // fallback, 40px max matches desktop.
+  padding-inline: clamp(1.25rem, 4vw, 2.5rem);
 }
 
 .hiw__grid {
   display: grid;
   grid-template-columns: 1fr 1.1fr;
-  gap: 32px;
+  // Fluid gap — shrinks from 32px desktop down to 16px at narrow widths,
+  // freeing horizontal space for the ledger + diagram cards on mobile.
+  gap: clamp(1rem, 3vw, 2rem);
   align-items: stretch;
   max-width: 1440px;
   margin: 0 auto;
 
   @media (max-width: 900px) {
     grid-template-columns: 1fr;
-    gap: 18px;
   }
 }
 

--- a/apps/web/src/features/homepage/HowItWorks/HowItWorks.module.scss
+++ b/apps/web/src/features/homepage/HowItWorks/HowItWorks.module.scss
@@ -632,13 +632,23 @@
   max-width: 1440px;
   margin: 32px auto 0;
 
+  // 5 → 3 → 2 cols so each button stays wide enough for comfortable
+  // touch targets (3-col at 900px gives ~280px/btn, 2-col at 560px
+  // gives ~260px/btn). The old 2-col-at-900 collapsed too aggressively.
   @media (max-width: 900px) {
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  @media (max-width: 560px) {
+    grid-template-columns: repeat(2, 1fr);
   }
 }
 
 .hiw__railButton {
-  padding: 18px 24px;
+  padding-inline: clamp(0.75rem, 2vw, 1.5rem);
+  padding-block: clamp(0.875rem, 2vw, 1.125rem);
+  // WCAG 2.2 Success Criterion 2.5.8 — Target Size Enhanced is 44×44 CSS px.
+  min-block-size: 44px;
   font-family: var(--ff-mono);
   font-size: 11px;
   letter-spacing: 0.14em;
@@ -680,9 +690,22 @@
     transition: width 0.5s var(--ease-out-expo);
   }
 
+  // Strip the right-border on the rightmost button of each layout's row so
+  // it doesn't sit against the rail's right edge as a dangling line.
   @media (max-width: 900px) {
+    &:nth-child(3n) {
+      border-right: 0;
+    }
+  }
+
+  @media (max-width: 560px) {
     &:nth-child(2n) {
       border-right: 0;
+    }
+    // Re-assert border-right on position 3 (which was cleared by the 3n
+    // rule above but sits mid-row in the 2-col layout).
+    &:nth-child(3) {
+      border-right: 1px solid var(--border);
     }
   }
 }

--- a/apps/web/src/features/homepage/Preloader/Preloader.module.scss
+++ b/apps/web/src/features/homepage/Preloader/Preloader.module.scss
@@ -22,6 +22,9 @@
   justify-content: center;
   color: #fff;
   overflow: hidden;
+  // Establish a size-query context so .intro__mark's font-size can track
+  // the overlay's actual inline size via cqw, not the viewport.
+  container-type: inline-size;
   animation: introOut 1.1s cubic-bezier(0.77, 0, 0.175, 1) 2.8s forwards;
 }
 
@@ -29,7 +32,10 @@
   position: relative;
   font-family: var(--ff-sans);
   font-weight: 600;
-  font-size: clamp(64px, 13vw, 200px);
+  // cqw scales with the .intro container (100% viewport width here), with a
+  // lower floor than the v6 clamp so "Blue Escrow" never overflows at 320px.
+  // 12cqw at 320px = 38.4 → min 44; text width 5.3em × 44 = 233px fits 320.
+  font-size: clamp(44px, 12cqw, 200px);
   line-height: 0.85;
   letter-spacing: -0.05em;
   white-space: nowrap;


### PR DESCRIPTION
Parent epic: #71 · Closes #72, #73

## Summary
User reported giant wordmarks (Preloader intro, Footer) clipping on narrow viewports, plus HowItWorks responsive edges. Root cause (verified by 8 parallel research agents + math):

> Viewport-based \`font-size: clamp(X, Nvw, Y)\` doesn't know the container width. At 375px viewport the Footer's \`20vw\` snapped to the 80px floor, rendering \"Blue Escrow.\" at **480px** inside a **327px** padded wrap — \`overflow: hidden\` clipped 153px.

**Fix:** migrate giant wordmarks to **CSS container queries (\`cqw\`)** so font-size tracks the actual parent, not the viewport. Plus HIW polish (fluid padding, WCAG 2.2 touch targets).

## Commits (5, 2 tracks, 1 PR)

### Track A — Giant wordmark container queries
| # | SHA | Change |
|---|---|---|
| A1 | \`5059df2\` | Preloader: \`container-type: inline-size\` on \`.intro\`; \`clamp(44px, 12cqw, 200px)\` (was \`clamp(64px, 13vw, 200px)\`) |
| A2 | \`661b6b6\` | Footer: \`container-type: inline-size\` on \`.footer__wrap\`; \`clamp(44px, 16cqw, 300px)\` (was \`clamp(80px, 20vw, 300px)\`); nowrap + outline stroke retained |
| A3 | \`5a79965\` | CtaSection heading: adds \`overflow-wrap: anywhere\` as safety net (no visual change with current copy) |

### Track B — HowItWorks responsive polish
| # | SHA | Change |
|---|---|---|
| B1 | \`e892c02\` | HIW: fluid padding + gap (\`clamp()\`), eliminates 720/900px jumps |
| B2 | \`cc1399c\` | HIW rail: 5→3→2 cols; \`min-block-size: 44px\` on buttons (WCAG 2.2 SC 2.5.8 Enhanced); border-right hygiene per layout |

## Verified math
- Footer 375px viewport: 327px wrap. 16cqw = 52.3px font → text 314px ✓ fits
- Footer 1440px viewport: 1360px wrap. 16cqw = 218px → clamp max 300 → ✓
- Preloader 320px viewport: 38.4 → floor 44 → text 233px ✓ fits 320
- HIW rail 320px viewport: 2-col → ~135px/btn × 44px high ✓ WCAG target

## Research methodology
- **8 parallel agents** (7 Explore + 1 WebSearch) in a single tool-call batch
- Every agent finding verified against actual \`file:line\` before acting (Phase 5 false-positive lesson)
- CSS Container Queries Level 1 — Baseline 2023-09
- WCAG 2.2 Success Criterion 2.5.8 — Target Size Enhanced 44×44

## Note on MCP servers
Playwright MCP and Chrome DevTools MCP are **not installed in this environment**. Visual regression smoke must be done manually post-merge by the user (DevTools device mode, resize at 320/375/414/560/640/720/820/900/1024/1280/1440/1920).

## Test plan
- [x] \`pnpm typecheck\` green (5x)
- [x] \`pnpm test\` — 134/134 pass (5x)
- [x] \`pnpm build\` green (5x)
- [ ] Visual: Preloader intro renders fully at 320-1920
- [ ] Visual: Footer giant renders fully at 320-1920, outline stroke intact
- [ ] Visual: CTA heading breaks cleanly, no mid-word clip
- [ ] Visual: HIW rail buttons all ≥ 44×44, no 720px padding jump, no horizontal scroll

## Deferred
- HIW SVG label size at 320px (cosmetic)
- Container queries rolled out to remaining sections (Hero, Receipts)
- View Transitions for theme toggle
- Lighthouse perf audit
- Preloader counter rAF → CSS counter animation

Refs #71.