### PR TITLE
fix(web): semantic pass — Compare <table>, Footer nav, CTA gradient, closes #75

### DIFF
--- a/apps/web/src/components/layout/Footer/Footer.test.tsx
+++ b/apps/web/src/components/layout/Footer/Footer.test.tsx
@@ -76,6 +76,45 @@ describe('Footer (v6)', () => {
     ).toBeDefined();
   });
 
+  it('wraps each link column in a <nav> with an accessible name (Product/Protocol/Directory)', () => {
+    render(<Footer />);
+    const footer = screen.getByRole('contentinfo');
+    const navs = within(footer).getAllByRole('navigation');
+    // Product + Protocol + Directory + the bottom legal <nav> = 4
+    expect(navs).toHaveLength(4);
+    const navLabels = navs.map((n) => n.getAttribute('aria-label'));
+    // Legal nav uses aria-label directly; 3 column navs use aria-labelledby
+    // pointing at the visible h3, so accessible name is derived from h3 text.
+    const productNav = within(footer).getByRole('navigation', {
+      name: 'Product',
+    });
+    const protocolNav = within(footer).getByRole('navigation', {
+      name: 'Protocol',
+    });
+    const directoryNav = within(footer).getByRole('navigation', {
+      name: 'Directory',
+    });
+    expect(productNav.tagName).toBe('NAV');
+    expect(protocolNav.tagName).toBe('NAV');
+    expect(directoryNav.tagName).toBe('NAV');
+    // Legal nav covered by the last test; sanity-check it's still in the list
+    expect(
+      navLabels.some((l) => /legal/i.test(l ?? '')),
+    ).toBe(true);
+  });
+
+  it('uses <h3> (not <h4>) for column headings so heading order is valid', () => {
+    const { container } = render(<Footer />);
+    const footer = container.querySelector('footer')!;
+    const colHeadings = footer.querySelectorAll<HTMLElement>(
+      '[class*="footer__colHeading"]',
+    );
+    expect(colHeadings.length).toBe(3);
+    colHeadings.forEach((h) => {
+      expect(h.tagName).toBe('H3');
+    });
+  });
+
   it('renders the 4 v6 legal bottom links (Terms, Privacy, Bug bounty, Legal)', () => {
     render(<Footer />);
     const footer = screen.getByRole('contentinfo');

--- a/apps/web/src/components/layout/Footer/Footer.tsx
+++ b/apps/web/src/components/layout/Footer/Footer.tsx
@@ -62,23 +62,32 @@ export function Footer() {
             <p className={styles.footer__tagline}>{TAGLINE}</p>
           </div>
 
-          {FOOTER_COLS.map((col) => (
-            <div key={col.heading} className={styles.footer__col}>
-              <h4 className={styles.footer__colHeading}>{col.heading}</h4>
-              <ul className={styles.footer__list}>
-                {col.links.map((link) => (
-                  <li key={link.label}>
-                    <Link
-                      href={link.href}
-                      className={styles.footer__link}
-                    >
-                      {link.label}
-                    </Link>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ))}
+          {FOOTER_COLS.map((col) => {
+            const headingId = `footer-col-${col.heading.toLowerCase()}`;
+            return (
+              <nav
+                key={col.heading}
+                className={styles.footer__col}
+                aria-labelledby={headingId}
+              >
+                <h3 id={headingId} className={styles.footer__colHeading}>
+                  {col.heading}
+                </h3>
+                <ul className={styles.footer__list}>
+                  {col.links.map((link) => (
+                    <li key={link.label}>
+                      <Link
+                        href={link.href}
+                        className={styles.footer__link}
+                      >
+                        {link.label}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </nav>
+            );
+          })}
         </div>
 
         <div className={styles.footer__bottom}>

--- a/apps/web/src/features/homepage/Compare/Compare.module.scss
+++ b/apps/web/src/features/homepage/Compare/Compare.module.scss
@@ -115,17 +115,31 @@
   text-wrap: pretty;
 }
 
+// Native <table> / <thead> / <tbody> / <tr> / <th> / <td> driven by CSS Grid.
+// display: contents on the structural wrappers flattens their children into
+// the table's grid so all cells participate in a single 4-col layout
+// (WCAG 2.2 SC 1.3.1 — tabular info uses table markup; Baseline 2024).
 .compare__table {
   display: grid;
   grid-template-columns: 1.6fr 1fr 1fr 1.2fr;
   border-top: 1px solid rgba(255, 255, 255, 0.18);
   margin-top: 20px;
+  // Reset table browser defaults that can bleed in.
+  border-collapse: collapse;
+  width: 100%;
 
   @media (max-width: 820px) {
     grid-template-columns: 1fr;
   }
 }
 
+.compare__table thead,
+.compare__table tbody,
+.compare__table tr {
+  display: contents;
+}
+
+.compare__headerRow,
 .compare__rowGroup {
   display: contents;
 }
@@ -134,6 +148,9 @@
   padding: 30px 22px;
   font-family: var(--ff-mono);
   font-size: 11px;
+  // <th> defaults to bold + center — reassert the v6 design.
+  font-weight: 500;
+  text-align: start;
   text-transform: uppercase;
   letter-spacing: 0.12em;
   color: rgba(255, 255, 255, 0.6);
@@ -163,6 +180,8 @@
   font-weight: 500;
   font-size: 15px;
   color: #fff;
+  // <th scope="row"> defaults to bold + center — reassert v6 design.
+  text-align: start;
   border-bottom: 1px solid rgba(255, 255, 255, 0.12);
   display: flex;
   align-items: center;

--- a/apps/web/src/features/homepage/Compare/Compare.test.tsx
+++ b/apps/web/src/features/homepage/Compare/Compare.test.tsx
@@ -24,18 +24,33 @@ describe('Compare (v6 .invert)', () => {
     ).toBeDefined();
   });
 
-  it('renders all 4 column headers', () => {
+  it('renders all 4 column headers as native <th scope="col">', () => {
     render(<Compare />);
-    expect(screen.getByText('Criteria')).toBeDefined();
-    expect(screen.getByText('Escrow.com')).toBeDefined();
-    expect(screen.getByText('Telegram middleman')).toBeDefined();
-    expect(screen.getByText('Blue Escrow')).toBeDefined();
+    const headers = screen.getAllByRole('columnheader');
+    expect(headers).toHaveLength(4);
+    expect(headers.map((h) => h.textContent?.trim())).toEqual([
+      'Criteria',
+      'Escrow.com',
+      'Telegram middleman',
+      'Blue Escrow',
+    ]);
+    // Every columnheader must be a <th> with scope="col"
+    headers.forEach((h) => {
+      expect(h.tagName).toBe('TH');
+      expect(h.getAttribute('scope')).toBe('col');
+    });
   });
 
-  it('renders every criterion row', () => {
+  it('renders every criterion row with native <th scope="row"> + 3 <td>', () => {
     render(<Compare />);
+    const rowheaders = screen.getAllByRole('rowheader');
+    expect(rowheaders).toHaveLength(COMPARE_ROWS.length);
+    rowheaders.forEach((rh, i) => {
+      expect(rh.tagName).toBe('TH');
+      expect(rh.getAttribute('scope')).toBe('row');
+      expect(rh.textContent).toBe(COMPARE_ROWS[i]!.criterion);
+    });
     COMPARE_ROWS.forEach((row) => {
-      expect(screen.getByText(row.criterion)).toBeDefined();
       expect(screen.getByText(row.escrow.label)).toBeDefined();
       expect(screen.getByText(row.telegram.label)).toBeDefined();
       expect(screen.getByText(row.blueEscrow.label)).toBeDefined();
@@ -51,9 +66,11 @@ describe('Compare (v6 .invert)', () => {
     );
   });
 
-  it('exposes a table via role semantics', () => {
-    render(<Compare />);
+  it('exposes a native <table> landmark with accessible name', () => {
+    const { container } = render(<Compare />);
     const table = screen.getByRole('table', { name: 'Comparison table' });
-    expect(table).toBeDefined();
+    expect(table.tagName).toBe('TABLE');
+    expect(container.querySelector('table thead')).not.toBeNull();
+    expect(container.querySelector('table tbody')).not.toBeNull();
   });
 });

--- a/apps/web/src/features/homepage/Compare/Compare.tsx
+++ b/apps/web/src/features/homepage/Compare/Compare.tsx
@@ -34,69 +34,74 @@ export function Compare() {
             </p>
           </div>
 
-          <div className={styles.compare__table} role="table" aria-label="Comparison table">
-            <div
-              className={styles.compare__headerCell}
-              role="columnheader"
-              data-animate="cell"
-            >
-              Criteria
-            </div>
-            <div
-              className={styles.compare__headerCell}
-              role="columnheader"
-              data-animate="cell"
-            >
-              Escrow.com
-            </div>
-            <div
-              className={styles.compare__headerCell}
-              role="columnheader"
-              data-animate="cell"
-            >
-              Telegram middleman
-            </div>
-            <div
-              className={`${styles.compare__headerCell} ${styles['compare__headerCell--be']}`}
-              role="columnheader"
-              data-animate="cell"
-            >
-              Blue Escrow
-            </div>
-
-            {COMPARE_ROWS.map((row) => (
-              <div key={row.criterion} className={styles.compare__rowGroup} role="row">
-                <div
-                  className={styles.compare__criterion}
-                  role="rowheader"
+          <table
+            className={styles.compare__table}
+            aria-label="Comparison table"
+          >
+            <thead>
+              <tr className={styles.compare__headerRow}>
+                <th
+                  scope="col"
+                  className={styles.compare__headerCell}
                   data-animate="cell"
                 >
-                  {row.criterion}
-                </div>
-                <div
-                  className={`${styles.compare__cell} ${STATUS_CLASS[row.escrow.status]}`}
-                  role="cell"
+                  Criteria
+                </th>
+                <th
+                  scope="col"
+                  className={styles.compare__headerCell}
                   data-animate="cell"
                 >
-                  {row.escrow.label}
-                </div>
-                <div
-                  className={`${styles.compare__cell} ${STATUS_CLASS[row.telegram.status]}`}
-                  role="cell"
+                  Escrow.com
+                </th>
+                <th
+                  scope="col"
+                  className={styles.compare__headerCell}
                   data-animate="cell"
                 >
-                  {row.telegram.label}
-                </div>
-                <div
-                  className={`${styles.compare__cell} ${styles['compare__cell--be']} ${STATUS_CLASS[row.blueEscrow.status]}`}
-                  role="cell"
+                  Telegram middleman
+                </th>
+                <th
+                  scope="col"
+                  className={`${styles.compare__headerCell} ${styles['compare__headerCell--be']}`}
                   data-animate="cell"
                 >
-                  {row.blueEscrow.label}
-                </div>
-              </div>
-            ))}
-          </div>
+                  Blue Escrow
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {COMPARE_ROWS.map((row) => (
+                <tr key={row.criterion} className={styles.compare__rowGroup}>
+                  <th
+                    scope="row"
+                    className={styles.compare__criterion}
+                    data-animate="cell"
+                  >
+                    {row.criterion}
+                  </th>
+                  <td
+                    className={`${styles.compare__cell} ${STATUS_CLASS[row.escrow.status]}`}
+                    data-animate="cell"
+                  >
+                    {row.escrow.label}
+                  </td>
+                  <td
+                    className={`${styles.compare__cell} ${STATUS_CLASS[row.telegram.status]}`}
+                    data-animate="cell"
+                  >
+                    {row.telegram.label}
+                  </td>
+                  <td
+                    className={`${styles.compare__cell} ${styles['compare__cell--be']} ${STATUS_CLASS[row.blueEscrow.status]}`}
+                    data-animate="cell"
+                  >
+                    {row.blueEscrow.label}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
       </CompareAnimations>
     </section>

--- a/apps/web/src/features/homepage/CtaSection/CtaSection.module.scss
+++ b/apps/web/src/features/homepage/CtaSection/CtaSection.module.scss
@@ -64,7 +64,13 @@
   overflow-wrap: anywhere;
 }
 
-.closing__emphasis {
+// Extends gradient clip to SplitText's <div> children so the italic
+// emphasis renders with its blue gradient even after word-splitting.
+// Without the `> div` selector, SplitText wraps words in divs, leaving
+// the parent <em>'s direct text empty — background-clip: text has
+// nothing to clip against, and the gradient paints invisibly.
+.closing__emphasis,
+.closing__emphasis > div {
   font-style: italic;
   font-weight: 400;
   background: var(--blue-band);


### PR DESCRIPTION
Closes #75.

## Summary
Post-merge QA on PR #74 (via chrome-devtools MCP) surfaced 3 pre-existing regressions. This PR fixes all three at the **root** — native HTML semantics everywhere.

## Commits
| # | SHA | Change |
|---|---|---|
| C1 | \`804faca\` | fix(web): Compare uses native <table> semantics + display:contents grid |
| C2 | \`711819c\` | fix(web): Footer column headings use h3 + nav landmarks |
| C3 | \`eddc6e0\` | fix(web): CtaSection italic gradient extends to SplitText-generated divs |

## What each commit fixes

**C1 — Compare table** (Lighthouse \`aria-required-children\` + \`aria-required-parent\`)
- Before: \`<div role="table">\` with \`<div role="columnheader">\` direct children, failing WAI-ARIA 1.2 row parent rule.
- After: native \`<table><thead><tr><th scope="col">\` / \`<tbody><tr><th scope="row"><td>\`.
- Layout preserved via \`display: contents\` on \`thead/tbody/tr\` (Baseline 2024) + CSS Grid on \`<table>\`.
- Zero ARIA roles now needed.

**C2 — Footer nav semantics** (Lighthouse \`heading-order\`)
- Before: \`<h4>\` column headings after page \`<h2>\`s — skips a level.
- After: \`<h3>\` wrapped in \`<nav aria-labelledby>\` — screen readers get 4 landmarks (Product, Protocol, Directory, Legal).

**C3 — CTA italic gradient** (visual regression discovered in QA)
- Before: SplitText's \`<div>\` wrappers inside \`<em>\` broke \`background-clip: text\` — "like you trust" rendered invisible.
- After: 4-line SCSS change targets \`.closing__emphasis > div\` too. Zero JS change.

## Standards anchor (2026)
- **WCAG 2.2 SC 1.3.1** — Info and Relationships satisfied by native table markup.
- **\`display: contents\` on table structural elements** — CSS Display Level 3, Baseline 2024.
- **\`<nav aria-labelledby>\`** — WAI-ARIA Landmark pattern for sub-navs.
- **\`background-clip: text\`** — CSS Backgrounds & Borders Level 4, Baseline 2024.

## Test plan
- [x] \`pnpm typecheck && pnpm test && pnpm build\` green on every commit
- [x] 134 → **136** tests passing (+2 assertions: Compare native th scope + Footer nav landmark count)
- [ ] Post-merge: re-run Lighthouse audit @ 1440×900 — target a11y ≥ 95 (was 88, target 100)
- [ ] Post-merge: re-capture CTA at 320/375/1440 — verify italic "like you trust" renders blue gradient
- [ ] Post-merge: re-capture Compare at 320/768/1440 — verify layout unchanged

## Files touched
- \`features/homepage/Compare/Compare.{tsx,module.scss,test.tsx}\`
- \`components/layout/Footer/Footer.{tsx,test.tsx}\`
- \`features/homepage/CtaSection/CtaSection.module.scss\`

Refs #75. Builds on PR #74 (\`0bc3abb\`).