### PR TITLE
fix(web): italic cohesion + ink-overflow hygiene (Preloader, CTA, Footer)

### DIFF
--- a/apps/web/src/components/layout/Footer/Footer.module.scss
+++ b/apps/web/src/components/layout/Footer/Footer.module.scss
@@ -40,7 +40,14 @@
   color: transparent;
   -webkit-text-stroke: 1px var(--accent);
   white-space: nowrap;
-  overflow: hidden;
+  // overflow: hidden removed — cqw sizing mathematically guarantees the
+  // wordmark fits inside .footer__wrap at every viewport, so clipping
+  // has no positive effect. It WAS silently chopping the italic ink on
+  // "Escrow." at the right edge on narrow viewports (the italic slant
+  // extends past the advance-width box). Leaving overflow at its
+  // default (visible) preserves the ink. If math ever drifts, the
+  // failure mode becomes a loud visible overflow instead of a silent
+  // ink clip — easier to spot.
 
   @media (max-width: 640px) {
     margin-bottom: 40px;

--- a/apps/web/src/features/homepage/CtaSection/CtaSection.module.scss
+++ b/apps/web/src/features/homepage/CtaSection/CtaSection.module.scss
@@ -30,6 +30,10 @@
   max-width: 1440px;
   margin: 0 auto;
   padding: 0 40px;
+  // Establishes a size-query context so .closing__emphasis can toggle
+  // white-space: nowrap on desktop widths (keeps "like you trust" cohesive)
+  // and allow natural wrap on mobile widths.
+  container-type: inline-size;
 
   @media (max-width: 720px) {
     padding: 0 24px;
@@ -49,7 +53,10 @@
 }
 
 .closing__heading {
-  font-size: clamp(60px, 12vw, 200px);
+  // Clamp cap 178 (was 200) so the italic phrase "like you trust" at
+  // ~7em width always fits the 1360px container even when held together
+  // as one unit by the @container query below. Matches v6 hero scale.
+  font-size: clamp(56px, 11vw, 178px);
   line-height: 0.9;
   letter-spacing: -0.05em;
   font-weight: 600;
@@ -59,8 +66,7 @@
   color: var(--text);
   // Belt-and-suspenders: text-wrap: balance may pick an unbalanced
   // break at some widths; overflow-wrap: anywhere lets a single word
-  // break if it ever exceeds max-width (defensive; no known trigger
-  // with current copy "Trade like you trust the code, not the person.").
+  // break if it ever exceeds max-width (defensive).
   overflow-wrap: anywhere;
 }
 
@@ -77,6 +83,18 @@
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
+}
+
+// At container widths ≥ 640px, keep the italic phrase "like you trust"
+// on a single line — text-wrap: balance on the parent h2 can otherwise
+// split the <em>'s words across two lines (e.g., "like you" / "trust"),
+// which reads as a visual cut of the emphasis. At narrower container
+// widths (mobile) the em is allowed to wrap naturally so the heading
+// still fits.
+@container (min-width: 640px) {
+  .closing__emphasis {
+    white-space: nowrap;
+  }
 }
 
 .closing__ctas {

--- a/apps/web/src/features/homepage/Preloader/Preloader.module.scss
+++ b/apps/web/src/features/homepage/Preloader/Preloader.module.scss
@@ -44,7 +44,10 @@
 
 .intro__word {
   display: inline-block;
-  overflow: hidden;
+  // overflow: clip (Baseline 2024) replaces `hidden` — same visual clip
+  // for the pre-animation translateY(110%) state, but doesn't establish
+  // a new scroll/containment context (cheaper + more predictable).
+  overflow: clip;
   vertical-align: top;
 }
 
@@ -52,6 +55,13 @@
   font-style: italic;
   font-weight: 400;
   letter-spacing: -0.04em;
+  // Italic letters' ink overshoots the advance-width box at the right
+  // edge (especially the "w" tail of "Escrow"). padding-inline-end
+  // gives the ink room before overflow: clip cuts it; the matching
+  // negative margin-inline-end preserves the visual gap to whatever
+  // follows. Net zero layout impact, ink preserved.
+  padding-inline-end: 0.08em;
+  margin-inline-end: -0.08em;
 }
 
 .intro__letter {


### PR DESCRIPTION
Closes #77. Follow-up to #75 / PR #74 / PR #76.

## Summary
User (1920×1080 screen) reported the "cut" they flagged earlier **still** appeared after PR #74 + #76. Reproduction via chrome-devtools MCP identified the actual root causes the earlier math-based QA missed (getBoundingClientRect returns advance-width box, not italic ink extent).

## Commits
| # | SHA | Change |
|---|---|---|
| C1 | \`9991c3e\` | fix(web): CtaSection em stays together via container query + clamp cap 178 |
| C2 | \`9152e71\` | fix(web): preloader italic word gives slant ink room (overflow: clip + padding) |
| C3 | \`19b11c7\` | fix(web): footer giant drops overflow:hidden (cqw already bounds text) |

## Root causes addressed

**C1 — CtaSection em divided across lines (primary user complaint)**

At 1920 with h2 width 1360 and font-size 200px, \`text-wrap: balance\` split the 9-word heading 3+3+3 for balanced widths — but it doesn't know about the \`<em>\` grouping. DOM showed em[0]+em[1] on line 1, em[2] alone on line 2. The italic phrase "like you trust" was visually halved.

Fix: \`.closing__wrap { container-type: inline-size }\` + \`@container (min-width: 640px) { .closing__emphasis { white-space: nowrap } }\`. At desktop container widths the italic phrase stays on one line (cohesive emphasis); at mobile it wraps naturally. Clamp cap reduced 200→178 so em (~7em wide) always fits the 1360px container when held together.

**C2 — Preloader italic "w" ink-clip**

Italic letters' ink overshoots the advance-width box at the slant edge. \`.intro__word { overflow: hidden }\` was chopping those ~0.08em of ink. Fix: \`overflow: hidden\` → \`overflow: clip\` (Baseline 2024) + \`padding-inline-end: 0.08em; margin-inline-end: -0.08em\` on italic word — gives ink breathing room while preserving visual spacing.

**C3 — Footer italic ink-clip at narrow viewports**

Same class of issue. cqw sizing from PR #74 already guarantees the text fits the container at every viewport — \`overflow: hidden\` was redundant and harmful. Removed.

## Standards anchor (2026)
- [MDN: CSS Container Queries](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Containment/Container_queries) — \`container-type: inline-size\` Baseline 2023-09
- CSS Overflow Level 3 \`overflow: clip\` Baseline 2024
- CSS Text Level 3 \`white-space: nowrap\`
- WCAG 2.2 SC 1.4.4 (text must be resizable to 200%)

## Test plan
- [x] \`pnpm typecheck && pnpm test && pnpm build\` green on each commit
- [x] 136/136 tests passing (no regressions)
- [ ] Post-merge: 11 viewports × 3 surfaces = 33 MCP checks (DOM + visual)
- [ ] Post-merge: Lighthouse a11y stays ≥ 95 (currently 100)
- [ ] Verify CTA em divs share same top at ≥ 640px container
- [ ] Verify preloader "w" right edge ink visible
- [ ] Verify footer italic "Escrow." ink visible 320→2560

## Files touched
- \`features/homepage/CtaSection/CtaSection.module.scss\`
- \`features/homepage/Preloader/Preloader.module.scss\`
- \`components/layout/Footer/Footer.module.scss\`

No markup or test changes required. Builds on PR #74 (\`0bc3abb\`) + PR #76 (\`db5d6c2\`).