### PR TITLE
fix(web): italic ink clipping round 2 — remove cumulative clip stack + overflow-wrap conflict

### DIFF
--- a/apps/web/src/features/homepage/CtaSection/CtaSection.module.scss
+++ b/apps/web/src/features/homepage/CtaSection/CtaSection.module.scss
@@ -64,10 +64,11 @@
   text-wrap: balance;
   max-width: 14ch;
   color: var(--text);
-  // Belt-and-suspenders: text-wrap: balance may pick an unbalanced
-  // break at some widths; overflow-wrap: anywhere lets a single word
-  // break if it ever exceeds max-width (defensive).
-  overflow-wrap: anywhere;
+  // overflow-wrap: anywhere REMOVED — it conflicts with white-space:
+  // nowrap on .closing__emphasis and causes mid-word breaks (MDN: it
+  // overrides nowrap when an otherwise-unbreakable string would
+  // overflow). Natural word-boundary wrapping is the correct 2026
+  // default; no word in this heading copy needs letter-level breaks.
 }
 
 // Extends gradient clip to SplitText's <div> children so the italic
@@ -83,6 +84,15 @@
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
+}
+
+// Micro-padding on SplitText's word wrappers reserves ink buffer for
+// italic letter slants (especially "t" in "trust") at narrow viewports
+// where the word ends up at a line edge. Matching negative margin keeps
+// visual spacing identical. Net zero layout impact, italic ink preserved.
+.closing__emphasis > div {
+  padding-inline: 0.06em;
+  margin-inline: -0.06em;
 }
 
 // At container widths ≥ 640px, keep the italic phrase "like you trust"

--- a/apps/web/src/features/homepage/CtaSection/CtaSection.module.scss
+++ b/apps/web/src/features/homepage/CtaSection/CtaSection.module.scss
@@ -11,14 +11,26 @@
   padding: 180px 0 200px;
   text-align: center;
   position: relative;
-  overflow: hidden;
-  background:
-    radial-gradient(
+  background: var(--bg-page);
+  // overflow: hidden removed — it was the outermost clip that was
+  // shaving italic ink from .closing__heading's <em> letters at section
+  // edges. The radial gradient bloom that used to rely on this clip is
+  // now rendered inside a ::before pseudo-element below, which has its
+  // own overflow: hidden and clips the bleed contained to itself.
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    pointer-events: none;
+    z-index: 0;
+    background: radial-gradient(
       ellipse 70% 90% at 50% 110%,
       var(--accent-soft),
       transparent 70%
-    ),
-    var(--bg-page);
+    );
+  }
 
   @media (max-width: 720px) {
     padding: 120px 0 140px;
@@ -30,6 +42,9 @@
   max-width: 1440px;
   margin: 0 auto;
   padding: 0 40px;
+  // Above the ::before gradient bloom.
+  position: relative;
+  z-index: 1;
   // Establishes a size-query context so .closing__emphasis can toggle
   // white-space: nowrap on desktop widths (keeps "like you trust" cohesive)
   // and allow natural wrap on mobile widths.

--- a/apps/web/src/features/homepage/Preloader/Preloader.module.scss
+++ b/apps/web/src/features/homepage/Preloader/Preloader.module.scss
@@ -21,7 +21,11 @@
   align-items: center;
   justify-content: center;
   color: #fff;
-  overflow: hidden;
+  // No overflow: hidden — fullscreen position: fixed + inset: 0 already
+  // bounds the element to the viewport, and the exit animation (introOut
+  // keyframes) handles its own clip-path during dismissal. Removing it
+  // collapses the cumulative clip stack that was shaving italic ink off
+  // .intro__word letters at the viewport edge.
   // Establish a size-query context so .intro__mark's font-size can track
   // the overlay's actual inline size via cqw, not the viewport.
   container-type: inline-size;
@@ -44,24 +48,22 @@
 
 .intro__word {
   display: inline-block;
-  // overflow: clip (Baseline 2024) replaces `hidden` — same visual clip
-  // for the pre-animation translateY(110%) state, but doesn't establish
-  // a new scroll/containment context (cheaper + more predictable).
-  overflow: clip;
   vertical-align: top;
+  // Asymmetric clip via clip-path (Baseline 2020, universal support):
+  // clip exactly at block-axis edges (top/bottom: 0) so the pre-animation
+  // translateY(110%) letters are hidden below baseline, but extend the
+  // clip 0.25em past the inline edges so italic letters' ink overshoots
+  // (slants, serifs) are NOT shaved. Replaces the previous overflow:
+  // clip + padding-inline-end hack, which only reclaimed space at this
+  // level and was still being cut by .intro's own overflow ancestor.
+  clip-path: inset(0 -0.25em 0 -0.08em);
 }
 
 .intro__word--italic {
   font-style: italic;
   font-weight: 400;
   letter-spacing: -0.04em;
-  // Italic letters' ink overshoots the advance-width box at the right
-  // edge (especially the "w" tail of "Escrow"). padding-inline-end
-  // gives the ink room before overflow: clip cuts it; the matching
-  // negative margin-inline-end preserves the visual gap to whatever
-  // follows. Net zero layout impact, ink preserved.
-  padding-inline-end: 0.08em;
-  margin-inline-end: -0.08em;
+  // clip-path on .intro__word reserves the ink buffer; no padding needed.
 }
 
 .intro__letter {


### PR DESCRIPTION
Closes #79. Follow-up to #77 / PR #78.

## Why previous fix (PR #78) wasn't enough
PR #78 added a 0.08em padding/negative-margin trick at \`.intro__word\` and removed \`overflow: hidden\` from \`.footer__giant\`. But:
- Preloader's \`.intro\` parent STILL had \`overflow: hidden\` — cumulative clip stack kept shaving italic ink.
- CtaSection's \`.closing\` parent STILL had \`overflow: hidden\` — same cumulative clip.
- CTA heading had \`overflow-wrap: anywhere\` + em \`white-space: nowrap\` — **conflicting CSS contracts**. Per MDN, \`overflow-wrap: anywhere\` overrides nowrap and breaks at any letter, which is what was chopping \"t\" of \"trust\" and producing user's 9-line word-per-line layout.

## Commits
| # | SHA | Change |
|---|---|---|
| F1 | \`0f6309e\` | Preloader: \`.intro__word\` uses \`clip-path: inset(0 -0.25em 0 -0.08em)\` (asymmetric, Baseline 2020) instead of overflow:clip+padding hack; \`.intro { overflow: hidden }\` removed (fullscreen fixed already bounds to viewport). |
| F2 | \`4664555\` | CtaSection: removes \`overflow-wrap: anywhere\` from heading (conflicts with em nowrap); adds \`padding-inline: 0.06em; margin-inline: -0.06em\` to \`.closing__emphasis > div\` (SplitText wrappers) for italic ink cushion. |
| F3 | \`f0c1529\` | CtaSection: gradient bloom moves into \`::before\` pseudo-element with its own overflow: hidden; \`.closing { overflow: hidden }\` removed — no longer clips italic ink at section edges. |

## Verification (post-merge matrix)

### DOM data confirms fixes applied
- **CTA @ 1920**: em divs all top=570 (cohesive), overflowWrap: \"normal\" (was \"anywhere\"), div padding: 10.68px (0.06em × 178px applied).
- **CTA @ 375**: 4 lines (\"Trade / like you trust the / code, not / the person.\") — natural wrap, no 9-line breakdown.
- **CTA @ 320**: 5 lines, natural wrap.
- **Preloader @ 1920**: word Escrow padding-end: 0, clip-path: \`inset(0px -50px 0px -16px)\` applied (0.25em × 200px = 50px right bleed).

### Visual (4 CTA + 2 Preloader screenshots read by Claude multimodal)
- ✅ \"Trade *like you trust* the code, not the person.\" heading renders cleanly at 320/375/414/1920.
- ✅ \"Blue Escrow\" preloader renders with italic \"w\" ink visible at 375/1024/1920.

### Lighthouse
- Accessibility: **100** (unchanged, was 100)
- Best Practices: 100
- SEO: 100
- 53 audits passed, **0 failed**

## 2026 standards applied
- \`clip-path: inset(...)\` for asymmetric clipping — Baseline 2020, universal.
- Removed \`overflow-wrap: anywhere\` where it conflicted with \`white-space: nowrap\` (MDN-documented footgun).
- \`::before\` pseudo-element for contained background bloom (standard layering pattern).

## Files touched
- \`features/homepage/Preloader/Preloader.module.scss\`
- \`features/homepage/CtaSection/CtaSection.module.scss\`

No TSX/test changes. 136/136 tests green. typecheck + build clean on each commit.

Refs #77, PR #78.