### PR TITLE
fix(web): 2026 best-practice rollout across entire homepage

### DIFF
--- a/apps/web/src/components/layout/Header/Header.module.scss
+++ b/apps/web/src/components/layout/Header/Header.module.scss
@@ -8,9 +8,8 @@
 
 .header {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
+  inset-block-start: 0;
+  inset-inline: 0;
   z-index: var(--z-header);
   display: flex;
   align-items: center;
@@ -123,8 +122,8 @@
   &::after {
     content: '';
     position: absolute;
-    left: 0;
-    bottom: -6px;
+    inset-inline-start: 0;
+    inset-block-end: -6px;
     width: 0;
     height: 1px;
     background: var(--accent);

--- a/apps/web/src/components/layout/Header/Header.module.scss
+++ b/apps/web/src/components/layout/Header/Header.module.scss
@@ -156,6 +156,11 @@
   font-size: 13px;
   color: var(--text);
   padding: 10px 18px;
+  // WCAG 2.2 SC 2.5.8 Enhanced: touch target ≥ 44×44 CSS px. At 10px
+  // vertical padding + 13px line-height, block-size was ~32px below
+  // target. min-block-size: 44px brings it into compliance without
+  // expanding the visual padding for sighted users.
+  min-block-size: 44px;
   border: 1px solid var(--on-border);
   border-radius: var(--radius-full);
   text-decoration: none;

--- a/apps/web/src/components/ui/Button/Button.module.scss
+++ b/apps/web/src/components/ui/Button/Button.module.scss
@@ -19,6 +19,8 @@
   cursor: pointer;
   text-decoration: none;
   white-space: nowrap;
+  // WCAG 2.2 SC 2.5.8 Enhanced: touch target ≥ 44×44 CSS px.
+  min-block-size: 44px;
   transition:
     background 250ms ease,
     color 250ms ease,

--- a/apps/web/src/components/ui/Button/Button.test.tsx
+++ b/apps/web/src/components/ui/Button/Button.test.tsx
@@ -1,11 +1,25 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
 import { Button } from './Button';
+
+afterEach(cleanup);
 
 describe('Button', () => {
   it('renders as a button element by default', () => {
     render(<Button>Click me</Button>);
     expect(screen.getByRole('button', { name: 'Click me' })).toBeDefined();
+  });
+
+  it('defaults type to "button" so it never accidentally submits a parent form', () => {
+    render(<Button>No explicit type</Button>);
+    const button = screen.getByRole('button', { name: 'No explicit type' });
+    expect(button.getAttribute('type')).toBe('button');
+  });
+
+  it('honors an explicit type="submit" when provided', () => {
+    render(<Button type="submit">Submit</Button>);
+    const button = screen.getByRole('button', { name: 'Submit' });
+    expect(button.getAttribute('type')).toBe('submit');
   });
 
   it('renders as an anchor when href is provided', () => {

--- a/apps/web/src/components/ui/Button/Button.tsx
+++ b/apps/web/src/components/ui/Button/Button.tsx
@@ -51,9 +51,10 @@ export function Button({
     );
   }
 
-  const { disabled, ...buttonProps } = rest as ButtonAsButton;
+  const { disabled, type, ...buttonProps } = rest as ButtonAsButton;
   return (
     <button
+      type={type ?? 'button'}
       className={classNames}
       disabled={disabled}
       {...buttonProps}

--- a/apps/web/src/features/homepage/Compare/Compare.module.scss
+++ b/apps/web/src/features/homepage/Compare/Compare.module.scss
@@ -217,7 +217,7 @@
     width: 8px;
     height: 8px;
     border-radius: 50%;
-    margin-right: 12px;
+    margin-inline-end: 12px;
     flex-shrink: 0;
     display: inline-block;
   }

--- a/apps/web/src/features/homepage/Compare/Compare.module.scss
+++ b/apps/web/src/features/homepage/Compare/Compare.module.scss
@@ -20,7 +20,8 @@
     ),
     linear-gradient(135deg, #0066ff 0%, #001b4d 100%);
   color: #fff;
-  padding: 160px 0 140px;
+  padding-block-start: clamp(100px, 9vw, 160px);
+  padding-block-end: clamp(80px, 8vw, 140px);
   position: relative;
   overflow: hidden;
   border-top: 1px solid rgba(255, 255, 255, 0.1);
@@ -41,9 +42,6 @@
       linear-gradient(135deg, #0055e0 0%, #001b4d 100%);
   }
 
-  @media (max-width: 720px) {
-    padding: 100px 0 80px;
-  }
 }
 
 .compare__wrap {

--- a/apps/web/src/features/homepage/Compare/Compare.module.scss
+++ b/apps/web/src/features/homepage/Compare/Compare.module.scss
@@ -51,6 +51,7 @@
   max-width: 1440px;
   margin: 0 auto;
   padding: 0 40px;
+  container-type: inline-size;
 
   @media (max-width: 720px) {
     padding: 0 24px;
@@ -105,6 +106,17 @@
   font-style: italic;
   font-weight: 400;
   color: #c5dcff;
+}
+
+@container (min-width: 640px) {
+  .compare__emphasis {
+    white-space: nowrap;
+  }
+}
+
+.compare__emphasis > div {
+  padding-inline: 0.06em;
+  margin-inline: -0.06em;
 }
 
 .compare__subtitle {

--- a/apps/web/src/features/homepage/Faq/Faq.module.scss
+++ b/apps/web/src/features/homepage/Faq/Faq.module.scss
@@ -19,6 +19,7 @@
   max-width: 1440px;
   margin: 0 auto;
   padding: 0 40px;
+  container-type: inline-size;
 
   @media (max-width: 720px) {
     padding: 0 24px;
@@ -73,6 +74,17 @@
   font-style: italic;
   color: var(--accent);
   font-weight: 400;
+}
+
+@container (min-width: 640px) {
+  .faq__emphasis {
+    white-space: nowrap;
+  }
+}
+
+.faq__emphasis > div {
+  padding-inline: 0.06em;
+  margin-inline: -0.06em;
 }
 
 .faq__subtitle {

--- a/apps/web/src/features/homepage/Faq/Faq.module.scss
+++ b/apps/web/src/features/homepage/Faq/Faq.module.scss
@@ -139,13 +139,13 @@
   font-size: 12px;
   color: var(--text-muted);
   letter-spacing: 0.1em;
-  margin-right: 32px;
+  margin-inline-end: 32px;
   flex-shrink: 0;
 }
 
 .faq__label {
   flex: 1;
-  padding-right: 24px;
+  padding-inline-end: 24px;
 }
 
 .faq__icon {
@@ -191,6 +191,6 @@
   }
 
   @media (max-width: 720px) {
-    padding-left: 8px;
+    padding-inline-start: 8px;
   }
 }

--- a/apps/web/src/features/homepage/FeeSection/FeeSection.module.scss
+++ b/apps/web/src/features/homepage/FeeSection/FeeSection.module.scss
@@ -6,14 +6,10 @@
 // ============================================================================
 
 .fees {
-  padding: 200px 0;
+  padding-block: clamp(120px, 11vw, 200px);
   position: relative;
   overflow: hidden;
   background: var(--bg-page);
-
-  @media (max-width: 720px) {
-    padding: 120px 0;
-  }
 }
 
 .fees__wrap {

--- a/apps/web/src/features/homepage/FeeSection/FeeSection.module.scss
+++ b/apps/web/src/features/homepage/FeeSection/FeeSection.module.scss
@@ -21,6 +21,7 @@
   max-width: 1440px;
   margin: 0 auto;
   padding: 0 40px;
+  container-type: inline-size;
 
   @media (max-width: 720px) {
     padding: 0 24px;
@@ -107,6 +108,17 @@
   font-style: italic;
   color: var(--accent);
   font-weight: 400;
+}
+
+@container (min-width: 640px) {
+  .fees__emphasis {
+    white-space: nowrap;
+  }
+}
+
+.fees__emphasis > div {
+  padding-inline: 0.06em;
+  margin-inline: -0.06em;
 }
 
 .fees__body {

--- a/apps/web/src/features/homepage/HowItWorks/HowItWorks.module.scss
+++ b/apps/web/src/features/homepage/HowItWorks/HowItWorks.module.scss
@@ -257,7 +257,7 @@
   letter-spacing: 0.14em;
   text-transform: uppercase;
   font-weight: 500;
-  margin-left: auto;
+  margin-inline-start: auto;
   align-self: center;
 }
 
@@ -308,7 +308,7 @@
   height: 8px;
   border-radius: 50%;
   background: var(--text-muted);
-  margin-right: 10px;
+  margin-inline-end: 10px;
   vertical-align: middle;
   transition:
     background 0.3s,
@@ -669,7 +669,7 @@
   text-transform: uppercase;
   color: var(--text-muted);
   border: none;
-  border-right: 1px solid var(--border);
+  border-inline-end: 1px solid var(--border);
   background: transparent;
   position: relative;
   transition:
@@ -680,7 +680,7 @@
   font-weight: inherit;
 
   &:last-child {
-    border-right: 0;
+    border-inline-end: 0;
   }
 
   &:hover {
@@ -696,8 +696,8 @@
   &::after {
     content: '';
     position: absolute;
-    left: 0;
-    top: -1px;
+    inset-inline-start: 0;
+    inset-block-start: -1px;
     height: 2px;
     width: 0;
     background: var(--accent);
@@ -708,18 +708,18 @@
   // it doesn't sit against the rail's right edge as a dangling line.
   @media (max-width: 900px) {
     &:nth-child(3n) {
-      border-right: 0;
+      border-inline-end: 0;
     }
   }
 
   @media (max-width: 560px) {
     &:nth-child(2n) {
-      border-right: 0;
+      border-inline-end: 0;
     }
     // Re-assert border-right on position 3 (which was cleared by the 3n
     // rule above but sits mid-row in the 2-col layout).
     &:nth-child(3) {
-      border-right: 1px solid var(--border);
+      border-inline-end: 1px solid var(--border);
     }
   }
 }
@@ -734,5 +734,5 @@
 
 .hiw__railNum {
   color: var(--accent);
-  margin-right: 10px;
+  margin-inline-end: 10px;
 }

--- a/apps/web/src/features/homepage/HowItWorks/HowItWorks.module.scss
+++ b/apps/web/src/features/homepage/HowItWorks/HowItWorks.module.scss
@@ -33,6 +33,8 @@
   // Mirror --container-padding (clamp(1.5rem, 4vw, 2.5rem)) — same tokens
   // used by .o-container, eliminating the 720px step.
   padding-inline: clamp(1.5rem, 4vw, 2.5rem);
+  // Size-query context for italic cohesion at desktop.
+  container-type: inline-size;
 }
 
 .hiw__head {
@@ -81,6 +83,18 @@
   font-style: italic;
   font-weight: 400;
   color: var(--accent);
+}
+
+// Desktop container widths: keep italic emphasis cohesive on one line.
+@container (min-width: 640px) {
+  .hiw__emphasis {
+    white-space: nowrap;
+  }
+}
+
+.hiw__emphasis > div {
+  padding-inline: 0.06em;
+  margin-inline: -0.06em;
 }
 
 .hiw__subtitle {

--- a/apps/web/src/features/homepage/Receipts/Receipts.module.scss
+++ b/apps/web/src/features/homepage/Receipts/Receipts.module.scss
@@ -8,12 +8,9 @@
 // ============================================================================
 
 .receipts {
-  padding: 180px 0 200px;
+  padding-block-start: clamp(120px, 10vw, 180px);
+  padding-block-end: clamp(140px, 11vw, 200px);
   overflow: hidden;
-
-  @media (max-width: 720px) {
-    padding: 120px 0 140px;
-  }
 }
 
 .receipts__wrap {

--- a/apps/web/src/features/homepage/Receipts/Receipts.module.scss
+++ b/apps/web/src/features/homepage/Receipts/Receipts.module.scss
@@ -21,6 +21,7 @@
   max-width: 1440px;
   margin: 0 auto;
   padding: 0 40px;
+  container-type: inline-size;
 
   @media (max-width: 720px) {
     padding: 0 24px;
@@ -75,6 +76,17 @@
   font-style: italic;
   font-weight: 400;
   color: var(--accent);
+}
+
+@container (min-width: 640px) {
+  .receipts__emphasis {
+    white-space: nowrap;
+  }
+}
+
+.receipts__emphasis > div {
+  padding-inline: 0.06em;
+  margin-inline: -0.06em;
 }
 
 .receipts__subtitle {

--- a/apps/web/src/features/homepage/TheProblem/TheProblem.module.scss
+++ b/apps/web/src/features/homepage/TheProblem/TheProblem.module.scss
@@ -77,9 +77,8 @@
   &::after {
     content: '';
     position: absolute;
-    left: -0.05em;
-    right: -0.05em;
-    top: 54%;
+    inset-inline: -0.05em;
+    inset-block-start: 54%;
     height: 4px;
     background: var(--status-error);
     transform: scaleX(0);

--- a/apps/web/src/features/homepage/TheProblem/TheProblem.module.scss
+++ b/apps/web/src/features/homepage/TheProblem/TheProblem.module.scss
@@ -7,12 +7,11 @@
 // ============================================================================
 
 .problem {
-  padding: 180px 0 160px;
+  // Fluid vertical rhythm — floor matches old mobile fallback, ceiling
+  // matches old desktop. Eliminates the 720px step.
+  padding-block-start: clamp(120px, 10vw, 180px);
+  padding-block-end: clamp(100px, 9vw, 160px);
   position: relative;
-
-  @media (max-width: 720px) {
-    padding: 120px 0 100px;
-  }
 }
 
 .problem__wrap {

--- a/apps/web/src/features/homepage/TheProblem/TheProblem.module.scss
+++ b/apps/web/src/features/homepage/TheProblem/TheProblem.module.scss
@@ -20,6 +20,10 @@
   max-width: 1440px;
   margin: 0 auto;
   padding: 0 40px;
+  // Size-query context so italic emphasis can toggle nowrap at desktop
+  // container widths (keeps the italic phrase cohesive when text-wrap:
+  // balance would otherwise split it across lines).
+  container-type: inline-size;
 
   @media (max-width: 720px) {
     padding: 0 24px;
@@ -101,6 +105,21 @@
   color: var(--accent);
   font-style: italic;
   font-weight: 400;
+}
+
+// At desktop container widths, keep italic emphasis cohesive (text-wrap:
+// balance on .problem__line can otherwise split phrases like "just leaving"
+// across lines, which reads as a visual cut).
+@container (min-width: 640px) {
+  .problem__italic {
+    white-space: nowrap;
+  }
+}
+
+// Defensive ink cushion for any SplitText children (no-op if not split).
+.problem__italic > div {
+  padding-inline: 0.06em;
+  margin-inline: -0.06em;
 }
 
 .problem__answer {

--- a/apps/web/src/features/homepage/TrustLayer/TrustLayer.module.scss
+++ b/apps/web/src/features/homepage/TrustLayer/TrustLayer.module.scss
@@ -24,6 +24,7 @@
   max-width: 1440px;
   margin: 0 auto;
   padding: 0 40px;
+  container-type: inline-size;
 
   @media (max-width: 720px) {
     padding: 0 24px;
@@ -78,6 +79,17 @@
   font-style: italic;
   font-weight: 400;
   color: var(--accent);
+}
+
+@container (min-width: 640px) {
+  .proof__emphasis {
+    white-space: nowrap;
+  }
+}
+
+.proof__emphasis > div {
+  padding-inline: 0.06em;
+  margin-inline: -0.06em;
 }
 
 .proof__subtitle {

--- a/apps/web/src/features/homepage/TrustLayer/TrustLayer.module.scss
+++ b/apps/web/src/features/homepage/TrustLayer/TrustLayer.module.scss
@@ -8,15 +8,12 @@
 // ============================================================================
 
 .proof {
-  padding: 180px 0 150px;
+  padding-block-start: clamp(120px, 10vw, 180px);
+  padding-block-end: clamp(100px, 9vw, 150px);
   background: var(--bg-surface);
   border-top: 1px solid var(--border);
   border-bottom: 1px solid var(--border);
   overflow: hidden;
-
-  @media (max-width: 720px) {
-    padding: 120px 0 100px;
-  }
 }
 
 .proof__wrap {

--- a/apps/web/src/features/homepage/TrustLayer/TrustLayer.module.scss
+++ b/apps/web/src/features/homepage/TrustLayer/TrustLayer.module.scss
@@ -113,15 +113,15 @@
 
 .proof__item {
   padding: 52px 32px 40px;
-  border-right: 1px solid var(--border);
+  border-inline-end: 1px solid var(--border);
 
   &:last-child {
-    border-right: none;
+    border-inline-end: none;
   }
 
   @media (max-width: 960px) {
     &:nth-child(2) {
-      border-right: none;
+      border-inline-end: none;
     }
 
     &:nth-child(-n + 2) {
@@ -149,7 +149,7 @@
   font-size: 0.32em;
   color: var(--accent);
   font-weight: 400;
-  margin-left: 4px;
+  margin-inline-start: 4px;
 }
 
 .proof__label {
@@ -188,6 +188,6 @@
   display: inline-block;
 
   span {
-    padding-right: 60px;
+    padding-inline-end: 60px;
   }
 }


### PR DESCRIPTION
Closes #81. Follow-up to #74 / #76 / #78 / #80 that applied 2026 patterns to CtaSection + Footer + Preloader. This PR rolls the same patterns across the REST of the homepage.

## 5 commits
| # | SHA | Change |
|---|---|---|
| C1 | \`4d114ef\` | italic cohesion (@container + ink cushion) on 7 section headings (TheProblem, HowItWorks, Compare, FeeSection, TrustLayer, Receipts, Faq) |
| C2 | \`ba92283\` | physical → logical CSS properties (margin-left/right → margin-inline-start/end, border-right → border-inline-end, top/left/right on absolute → inset-block/inline) |
| C3 | \`793c183\` | min-block-size: 44px on Button + Header CTA (WCAG 2.2 SC 2.5.8 Enhanced) |
| C4 | \`adc74ac\` | fluid section padding via clamp() on 5 sections (kills 720px step) |
| C5 | \`331024f\` | Button defaults type="button" to prevent accidental form submits |

## What each commit achieves

**C1** — Every section heading with italic `<em>` now exhibits the same cohesion behavior CtaSection got in PR #78: at desktop container widths (≥640) the italic phrase stays on one line; at mobile it wraps naturally. Plus a defensive ink cushion on SplitText children.

**C2** — 20+ physical CSS property instances converted to logical equivalents. Homepage is now RTL-ready (when \`dir=\"rtl\"\` is set, everything mirrors correctly). Zero LTR visual change.

**C3** — WCAG 2.2 SC 2.5.8 Enhanced compliance on Button sm variant (was ~40px) and Header CTA (was ~32px). Both now enforce min-block-size: 44px.

**C4** — 5 section paddings migrate from hardcoded 180/200px + 720px media query fallback to fluid \`clamp()\`. No more visible jolt at 720px; scales smoothly from 320 to 2560.

**C5** — \`Button\` component no longer inherits HTML spec default \`type=\"submit\"\`. Safe default is \`type=\"button\"\`; explicit submits still work.

## 2026 standards applied
- [MDN: Container Queries](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Containment/Container_queries) — Baseline 2023
- [MDN: CSS Logical Properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values) — Baseline 2020
- [WCAG 2.2 SC 2.5.8 Target Size](https://www.w3.org/TR/WCAG22/)
- [MDN: `<button type>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#type)

## Test plan
- [x] \`pnpm typecheck && pnpm test && pnpm build\` green on each commit
- [x] Tests: 136 → **138** (+2 for Button type default)
- [ ] Post-merge Lighthouse a11y + DOM sampling
- [ ] Visual sanity on 7 section headings + Button at 1920 + 375 = ~16 screenshots

## Files touched
8 SCSS files across homepage/components, 1 TSX + 1 test file. No markup changes.

Refs: #74, #76, #78, #80, #81.