### PR TITLE
(feat) HIW v8 · contract-accurate Safeguards redesign, refs #38 #101

### DIFF
--- a/apps/web/src/features/homepage/HowItWorks/HiwDiagram.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/HiwDiagram.tsx
@@ -3,7 +3,7 @@ import {
   ActorGroup,
   CLIENT_GLYPH,
   HiwDefs,
-  MIDDLEMAN_GLYPH,
+  JudgePodium,
   MoneyPacket,
   SELLER_GLYPH,
   VaultCore,
@@ -50,15 +50,7 @@ export function HiwDiagram() {
         meta="0x7a2f…e91c"
         glyph={CLIENT_GLYPH}
       />
-      <ActorGroup
-        kind="mid"
-        x={600}
-        y={120}
-        role="MIDDLEMAN"
-        name="@archer"
-        meta="REP 4.98 · 214 deals"
-        glyph={MIDDLEMAN_GLYPH}
-      />
+      <JudgePodium />
       <ActorGroup
         kind="seller"
         x={1020}

--- a/apps/web/src/features/homepage/HowItWorks/HiwDiagram.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/HiwDiagram.tsx
@@ -1,5 +1,24 @@
 import styles from './HowItWorks.module.scss';
+import {
+  ActorGroup,
+  CLIENT_GLYPH,
+  HiwDefs,
+  MIDDLEMAN_GLYPH,
+  MoneyPacket,
+  SELLER_GLYPH,
+  VaultCore,
+  WireNetwork,
+} from './svg';
 
+/**
+ * v7 "Live Contract View" diagram — composed from svg/ subcomponents.
+ *
+ * This commit is a pure structural split; the rendered SVG output is
+ * byte-identical to the pre-split version, so the existing
+ * howitworks-visual + hiw-a11y + hiw-responsive-type e2e baselines stay
+ * green. Commits 5-6 evolve the geometry (judge podium, hex vault) on
+ * top of this composition.
+ */
 export function HiwDiagram() {
   return (
     <svg
@@ -18,355 +37,39 @@ export function HiwDiagram() {
         seller when funds are released.
       </desc>
 
-      <defs>
-        <radialGradient id="hiw-core-grad" cx="50%" cy="40%" r="60%">
-          <stop offset="0" stopColor="#33AAFF" />
-          <stop offset="60%" stopColor="#0066FF" />
-          <stop offset="100%" stopColor="#001B4D" />
-        </radialGradient>
-        <filter
-          id="hiw-core-glow"
-          x="-50%"
-          y="-50%"
-          width="200%"
-          height="200%"
-        >
-          <feGaussianBlur stdDeviation="8" result="b" />
-          <feMerge>
-            <feMergeNode in="b" />
-            <feMergeNode in="SourceGraphic" />
-          </feMerge>
-        </filter>
-        <linearGradient id="hiw-wire-grad" x1="0" x2="1">
-          <stop offset="0" stopColor="#0091FF" stopOpacity="0" />
-          <stop offset=".5" stopColor="#0091FF" />
-          <stop offset="1" stopColor="#0091FF" stopOpacity="0" />
-        </linearGradient>
-        <filter
-          id="hiw-packet-trail"
-          x="-50%"
-          y="-50%"
-          width="200%"
-          height="200%"
-        >
-          <feGaussianBlur in="SourceGraphic" stdDeviation="0" />
-        </filter>
-        <filter
-          id="hiw-core-rim"
-          x="-50%"
-          y="-50%"
-          width="200%"
-          height="200%"
-        >
-          <feGaussianBlur in="SourceAlpha" stdDeviation="3" />
-          <feOffset dx="0" dy="0" />
-          <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1" />
-          <feColorMatrix values="0 0 0 0 0.2  0 0 0 0 0.67  0 0 0 0 1  0 0 0 1 0" />
-          <feComposite in2="SourceGraphic" operator="in" />
-          <feMerge>
-            <feMergeNode />
-            <feMergeNode in="SourceGraphic" />
-          </feMerge>
-        </filter>
-      </defs>
+      <HiwDefs />
+      <WireNetwork />
+      <VaultCore />
 
-      {/* Concentric orbits around the contract core — decorative. */}
-      <g data-hiw="orbits" opacity="0" aria-hidden="true">
-        <circle
-          cx="600"
-          cy="380"
-          r="180"
-          fill="none"
-          stroke="#0091FF"
-          strokeOpacity=".15"
-          strokeDasharray="2 6"
-          vectorEffect="non-scaling-stroke"
-        />
-        <circle
-          cx="600"
-          cy="380"
-          r="260"
-          fill="none"
-          stroke="#0091FF"
-          strokeOpacity=".1"
-          strokeDasharray="2 8"
-          vectorEffect="non-scaling-stroke"
-        />
-        <circle
-          cx="600"
-          cy="380"
-          r="340"
-          fill="none"
-          stroke="#0091FF"
-          strokeOpacity=".07"
-          strokeDasharray="2 10"
-          vectorEffect="non-scaling-stroke"
-        />
-      </g>
+      <ActorGroup
+        kind="client"
+        x={180}
+        y={420}
+        role="CLIENT"
+        name="Sofia R."
+        meta="0x7a2f…e91c"
+        glyph={CLIENT_GLYPH}
+      />
+      <ActorGroup
+        kind="mid"
+        x={600}
+        y={120}
+        role="MIDDLEMAN"
+        name="@archer"
+        meta="REP 4.98 · 214 deals"
+        glyph={MIDDLEMAN_GLYPH}
+      />
+      <ActorGroup
+        kind="seller"
+        x={1020}
+        y={420}
+        role="SELLER"
+        name="Diego M."
+        meta="0xd20e…77ab"
+        glyph={SELLER_GLYPH}
+      />
 
-      {/* Wires — base dashed (always visible) + active gradient overlays (tweened) */}
-      <g strokeLinecap="round" fill="none" strokeWidth="1.5" aria-hidden="true">
-        <path
-          data-hiw="wire-base-C"
-          className={styles.hiw__diagWire}
-          d="M 260 420 Q 420 420 540 400"
-          strokeDasharray="5 6"
-        />
-        <path
-          data-hiw="wire-base-M"
-          className={styles.hiw__diagWire}
-          d="M 600 180 Q 600 280 600 340"
-          strokeDasharray="5 6"
-        />
-        <path
-          data-hiw="wire-base-S"
-          className={styles.hiw__diagWire}
-          d="M 940 420 Q 780 420 660 400"
-          strokeDasharray="5 6"
-        />
-
-        <path
-          data-hiw="wire-active-C"
-          d="M 260 420 Q 420 420 540 400"
-          stroke="url(#hiw-wire-grad)"
-          strokeWidth="2"
-          opacity="0"
-        />
-        <path
-          data-hiw="wire-active-M"
-          d="M 600 180 Q 600 280 600 340"
-          stroke="url(#hiw-wire-grad)"
-          strokeWidth="2"
-          opacity="0"
-        />
-        <path
-          data-hiw="wire-active-S"
-          d="M 940 420 Q 780 420 660 400"
-          stroke="url(#hiw-wire-grad)"
-          strokeWidth="2"
-          opacity="0"
-        />
-      </g>
-
-      {/* Contract core */}
-      <g data-hiw="core">
-        <circle
-          data-hiw="core-halo"
-          cx="600"
-          cy="380"
-          r="110"
-          fill="#0091FF"
-          fillOpacity="0"
-          filter="url(#hiw-core-glow)"
-          aria-hidden="true"
-        />
-        <circle
-          cx="600"
-          cy="380"
-          r="85"
-          fill="none"
-          stroke="#0091FF"
-          strokeOpacity=".5"
-          strokeDasharray="4 5"
-          vectorEffect="non-scaling-stroke"
-          aria-hidden="true"
-        />
-        <circle
-          cx="600"
-          cy="380"
-          r="60"
-          fill="url(#hiw-core-grad)"
-          stroke="#0091FF"
-          strokeWidth="1"
-        />
-        <g
-          transform="translate(600 380)"
-          fill="none"
-          stroke="#fff"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden="true"
-        >
-          <rect x="-14" y="-4" width="28" height="20" rx="3" />
-          <path d="M -9 -4 V -10 A 9 9 0 0 1 9 -10 V -4" />
-        </g>
-        <text
-          x="600"
-          y="468"
-          textAnchor="middle"
-          className={styles.hiw__diagCoreLabel}
-        >
-          SMART CONTRACT
-        </text>
-        <text
-          x="600"
-          y="498"
-          textAnchor="middle"
-          className={styles.hiw__diagCoreTitle}
-        >
-          Escrow #4821
-        </text>
-      </g>
-
-      {/* CLIENT actor */}
-      <g data-hiw="actor-client" transform="translate(180 420)" opacity="0">
-        <circle r="56" className={styles.hiw__diagActorPuck} strokeWidth="1" />
-        <circle
-          r="66"
-          fill="none"
-          stroke="#0091FF"
-          strokeOpacity=".3"
-          strokeDasharray="2 5"
-          vectorEffect="non-scaling-stroke"
-          aria-hidden="true"
-        />
-        <g
-          stroke="#0091FF"
-          strokeWidth="1.6"
-          fill="none"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden="true"
-        >
-          <path d="M 0 -16 L -14 -8 V 6 C -14 16 -8 22 0 24 C 8 22 14 16 14 6 V -8 Z" />
-        </g>
-        <text
-          y="-92"
-          textAnchor="middle"
-          className={styles.hiw__diagActorRole}
-        >
-          CLIENT
-        </text>
-        <text
-          y="100"
-          textAnchor="middle"
-          className={styles.hiw__diagActorText}
-        >
-          Sofia R.
-        </text>
-        <text
-          y="132"
-          textAnchor="middle"
-          className={styles.hiw__diagActorMuted}
-        >
-          0x7a2f…e91c
-        </text>
-      </g>
-
-      {/* MIDDLEMAN actor */}
-      <g data-hiw="actor-mid" transform="translate(600 120)" opacity="0">
-        <circle r="56" className={styles.hiw__diagActorPuck} strokeWidth="1" />
-        <circle
-          r="66"
-          fill="none"
-          stroke="#0091FF"
-          strokeOpacity=".3"
-          strokeDasharray="2 5"
-          vectorEffect="non-scaling-stroke"
-          aria-hidden="true"
-        />
-        <g
-          stroke="#0091FF"
-          strokeWidth="1.6"
-          fill="none"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden="true"
-        >
-          <path d="M 0 -18 L 16 -10 V 8 L 0 20 L -16 8 V -10 Z" />
-          <path d="M -16 -2 L 16 -2" />
-        </g>
-        <text
-          y="-92"
-          textAnchor="middle"
-          className={styles.hiw__diagActorRole}
-        >
-          MIDDLEMAN
-        </text>
-        <text
-          y="100"
-          textAnchor="middle"
-          className={styles.hiw__diagActorText}
-        >
-          @archer
-        </text>
-        <text
-          y="132"
-          textAnchor="middle"
-          className={styles.hiw__diagActorMuted}
-        >
-          REP 4.98 · 214 deals
-        </text>
-      </g>
-
-      {/* SELLER actor */}
-      <g data-hiw="actor-seller" transform="translate(1020 420)" opacity="0">
-        <circle r="56" className={styles.hiw__diagActorPuck} strokeWidth="1" />
-        <circle
-          r="66"
-          fill="none"
-          stroke="#0091FF"
-          strokeOpacity=".3"
-          strokeDasharray="2 5"
-          vectorEffect="non-scaling-stroke"
-          aria-hidden="true"
-        />
-        <g
-          stroke="#0091FF"
-          strokeWidth="1.6"
-          fill="none"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden="true"
-        >
-          <path d="M -14 -12 H 14 L 18 14 A 2 2 0 0 1 16 16 H -16 A 2 2 0 0 1 -18 14 Z" />
-          <path d="M -6 -12 V -18 A 6 6 0 0 1 6 -18 V -12" />
-        </g>
-        <text
-          y="-92"
-          textAnchor="middle"
-          className={styles.hiw__diagActorRole}
-        >
-          SELLER
-        </text>
-        <text
-          y="100"
-          textAnchor="middle"
-          className={styles.hiw__diagActorText}
-        >
-          Diego M.
-        </text>
-        <text
-          y="132"
-          textAnchor="middle"
-          className={styles.hiw__diagActorMuted}
-        >
-          0xd20e…77ab
-        </text>
-      </g>
-
-      {/* Money packet — position tweened by the timeline (GSAP seeds via gsap.set) */}
-      <g data-hiw="packet" opacity="0" filter="url(#hiw-packet-trail)">
-        <rect
-          x="-28"
-          y="-14"
-          width="56"
-          height="28"
-          rx="14"
-          fill="#fff"
-          stroke="#0091FF"
-          strokeWidth="1.5"
-        />
-        <text
-          textAnchor="middle"
-          y="5"
-          fill="#001B4D"
-          className={styles.hiw__diagPacket}
-        >
-          $2,400
-        </text>
-      </g>
+      <MoneyPacket />
     </svg>
   );
 }

--- a/apps/web/src/features/homepage/HowItWorks/HowItWorks.integration.test.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/HowItWorks.integration.test.tsx
@@ -1,0 +1,179 @@
+// ---------------------------------------------------------------------------
+// HowItWorks integration — ties the v8 Safeguards redesign together.
+//
+// The unit tests in Safeguards/, svg/, animations/, and context/ each cover
+// their own surface in isolation. This spec exercises the full chain so any
+// broken wire between:
+//
+//   click(tab) → HiwContext.setOutcome(id)
+//              → Safeguards hidden attribute swap
+//              → useOutcomeBranch → data-hiw-outcome + CSS custom props on
+//                the HowItWorks <section>
+//              → announceOutcome → live region text
+//
+// lights up as a real regression, not a silent drift between layers.
+// Mocks HowItWorksAnimations and HiwPhaseDiagram (they own GSAP + heavy
+// SVG) so the integration test stays vitest-fast.
+// ---------------------------------------------------------------------------
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/react';
+
+vi.mock('./HowItWorksAnimations', () => ({
+  HowItWorksAnimations: ({
+    children,
+  }: {
+    children: React.ReactNode;
+    stageRef: unknown;
+    onPhaseChange: (p: 0 | 1 | 2 | 3 | 4) => void;
+  }) => <div>{children}</div>,
+}));
+
+vi.mock('./HiwPhaseDiagram', () => ({
+  HiwPhaseDiagram: () => null,
+}));
+
+vi.mock('@/providers/LenisProvider', () => ({
+  useLenisInstance: () => ({ scrollTo: vi.fn() }),
+}));
+
+import { HowItWorks } from './HowItWorks';
+
+afterEach(cleanup);
+
+type OutcomeCase = {
+  id: 'refund' | 'disputeBuyer' | 'disputeSeller' | 'timeout';
+  judgeOpacity: '0.3' | '1';
+  feeApplies: '0' | '1';
+  soulboundMint: '0' | '1';
+  announcement: RegExp;
+};
+
+const CASES: OutcomeCase[] = [
+  {
+    id: 'refund',
+    judgeOpacity: '0.3',
+    feeApplies: '0',
+    soulboundMint: '0',
+    announcement: /Refund outcome selected/i,
+  },
+  {
+    id: 'disputeBuyer',
+    judgeOpacity: '1',
+    feeApplies: '0',
+    soulboundMint: '1',
+    announcement: /Dispute.*Buyer/i,
+  },
+  {
+    id: 'disputeSeller',
+    judgeOpacity: '1',
+    feeApplies: '1',
+    soulboundMint: '1',
+    announcement: /Dispute.*Seller/i,
+  },
+  {
+    id: 'timeout',
+    judgeOpacity: '0.3',
+    feeApplies: '0',
+    soulboundMint: '0',
+    announcement: /Timeout outcome selected/i,
+  },
+];
+
+describe('HowItWorks integration · Safeguards → section state chain', () => {
+  it('starts on happy path (data-hiw-outcome="happy", all chips aria-selected=false)', () => {
+    const { container } = render(<HowItWorks />);
+    const section = container.querySelector('section#hiw')!;
+    expect(section.getAttribute('data-hiw-outcome')).toBe('happy');
+    for (const chip of container.querySelectorAll('[data-hiw-outcome-chip]')) {
+      expect(chip.getAttribute('aria-selected')).toBe('false');
+    }
+  });
+
+  it.each(CASES)(
+    'clicking the $id chip propagates to data-hiw-outcome + CSS vars + live announcer',
+    ({ id, judgeOpacity, feeApplies, soulboundMint, announcement }) => {
+      const { container } = render(<HowItWorks />);
+      const section = container.querySelector<HTMLElement>('section#hiw')!;
+      const chip = container.querySelector<HTMLButtonElement>(
+        `[data-hiw-outcome-chip="${id}"]`,
+      )!;
+
+      fireEvent.click(chip);
+
+      // (a) context-owned state
+      expect(chip.getAttribute('aria-selected')).toBe('true');
+
+      // (b) useOutcomeBranch wrote the section attribute + CSS vars
+      expect(section.getAttribute('data-hiw-outcome')).toBe(id);
+      expect(section.style.getPropertyValue('--hiw-judge-opacity')).toBe(
+        judgeOpacity,
+      );
+      expect(section.style.getPropertyValue('--hiw-fee-applies')).toBe(
+        feeApplies,
+      );
+      expect(section.style.getPropertyValue('--hiw-outcome-active')).toBe('1');
+      expect(section.style.getPropertyValue('--hiw-soulbound-mint')).toBe(
+        soulboundMint,
+      );
+
+      // (c) matching panel revealed, others hidden
+      const panels = container.querySelectorAll('[data-hiw-outcome-panel]');
+      for (const panel of panels) {
+        const panelId = panel.getAttribute('data-hiw-outcome-panel');
+        if (panelId === id) {
+          expect(panel.hasAttribute('hidden')).toBe(false);
+        } else {
+          expect(panel.hasAttribute('hidden')).toBe(true);
+        }
+      }
+
+      // (d) announcer text reflects the outcome
+      const live = container.querySelector('[data-hiw-outcome-announcer]')!;
+      expect(live.textContent ?? '').toMatch(announcement);
+    },
+  );
+
+  it('re-clicking the active chip resets the whole chain to happy path', () => {
+    const { container } = render(<HowItWorks />);
+    const section = container.querySelector<HTMLElement>('section#hiw')!;
+    const chip = container.querySelector<HTMLButtonElement>(
+      '[data-hiw-outcome-chip="disputeSeller"]',
+    )!;
+
+    fireEvent.click(chip); // enter dispute-seller
+    expect(section.getAttribute('data-hiw-outcome')).toBe('disputeSeller');
+
+    fireEvent.click(chip); // toggle back to happy
+    expect(section.getAttribute('data-hiw-outcome')).toBe('happy');
+    expect(section.style.getPropertyValue('--hiw-outcome-active')).toBe('0');
+    expect(section.style.getPropertyValue('--hiw-judge-opacity')).toBe('0.3');
+    // All panels hidden again
+    for (const panel of container.querySelectorAll('[data-hiw-outcome-panel]')) {
+      expect(panel.hasAttribute('hidden')).toBe(true);
+    }
+  });
+
+  it('fee-applies flag stays aligned with the Solidity rule across every outcome', () => {
+    // This is the same invariant the data/contract-map.test covers at the
+    // data layer; here we prove the integration preserves it end-to-end.
+    const { container } = render(<HowItWorks />);
+    const section = container.querySelector<HTMLElement>('section#hiw')!;
+
+    const expectations: Array<[string, '0' | '1']> = [
+      ['refund', '0'],
+      ['disputeBuyer', '0'],
+      ['disputeSeller', '1'],
+      ['timeout', '0'],
+    ];
+    for (const [id, fee] of expectations) {
+      const chip = container.querySelector<HTMLButtonElement>(
+        `[data-hiw-outcome-chip="${id}"]`,
+      )!;
+      fireEvent.click(chip);
+      expect(section.style.getPropertyValue('--hiw-fee-applies')).toBe(fee);
+      // Toggle back so the next outcome starts from happy path
+      fireEvent.click(chip);
+    }
+  });
+});

--- a/apps/web/src/features/homepage/HowItWorks/HowItWorks.integration.test.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/HowItWorks.integration.test.tsx
@@ -54,7 +54,7 @@ const CASES: OutcomeCase[] = [
     id: 'refund',
     judgeOpacity: '0.3',
     feeApplies: '0',
-    soulboundMint: '0',
+    soulboundMint: '1', // _resolveDeal always mints soulbound (Escrow.sol:601)
     announcement: /Refund outcome selected/i,
   },
   {
@@ -75,7 +75,7 @@ const CASES: OutcomeCase[] = [
     id: 'timeout',
     judgeOpacity: '0.3',
     feeApplies: '0',
-    soulboundMint: '0',
+    soulboundMint: '1',
     announcement: /Timeout outcome selected/i,
   },
 ];

--- a/apps/web/src/features/homepage/HowItWorks/HowItWorks.module.scss
+++ b/apps/web/src/features/homepage/HowItWorks/HowItWorks.module.scss
@@ -156,6 +156,9 @@
   // Rail progress (0 → 1) is likewise written from scrub; inherited down
   // into .hiw__railProgress > i.
   --hiw-rail-progress: 0;
+  // Middleman judge-podium dimmer (0 happy-path standby, 1 dispute active).
+  // Dispute branch timelines overwrite this via the outcome context.
+  --hiw-judge-opacity: 0.3;
 
   // Deep navy radial well — color-mix against --blue-ink for theme cohesion.
   &::before {
@@ -652,6 +655,68 @@
   font-weight: 700;
 }
 
+// ---------------------------------------------------------------------------
+// JudgePodium — middleman elevated as a judge/referee.
+//
+// The inner `.hiw__diagJudgeBody` group multiplies its opacity against the
+// outer `data-hiw="actor-mid"` group's GSAP-driven opacity. GSAP owns
+// entrance (0 → 1 during the Meet phase); this CSS var owns dimming (0.30
+// on the happy path, 1.0 on Dispute branches). Dispute timelines write
+// the var directly so scrub + branch switching don't fight each other.
+// ---------------------------------------------------------------------------
+
+.hiw__diagJudgeBody {
+  opacity: var(--hiw-judge-opacity, 0.3);
+  transition: opacity var(--dur-default, 500ms) var(--ease-out-expo, cubic-bezier(0.19, 1, 0.22, 1));
+}
+
+.hiw__diagJudgePodium {
+  fill: color-mix(in oklch, var(--hiw-actor-bg) 65%, transparent);
+  stroke: var(--hiw-actor-border);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+
+.hiw__diagJudgeHex {
+  fill: var(--hiw-actor-bg);
+  stroke: var(--hiw-actor-border);
+}
+
+.hiw__diagJudgeGavel {
+  fill: var(--hiw-role-label);
+  stroke: none;
+}
+
+.hiw__diagJudgeGavelBlock {
+  fill: color-mix(in oklch, var(--hiw-role-label) 45%, transparent);
+}
+
+.hiw__diagJudgeScales {
+  fill: none;
+  stroke: var(--hiw-role-label);
+  stroke-width: 1.2;
+  stroke-opacity: 0.55;
+  stroke-linecap: round;
+  vector-effect: non-scaling-stroke;
+}
+
+.hiw__diagJudgeChip {
+  fill: color-mix(in oklch, var(--hiw-actor-bg) 80%, transparent);
+  stroke: var(--hiw-actor-border);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+
+.hiw__diagJudgeChipLabel {
+  fill: var(--hiw-role-label);
+  font-family: var(--ff-mono);
+  // Container-query sized so 320px mobile stays readable; ceiling 14 keeps
+  // the pill shorter than the 224px chip width at desktop scale.
+  font-size: clamp(11px, 1.7cqi, 14px);
+  font-weight: 500;
+  letter-spacing: 0.04em;
+}
+
 // `prefers-contrast: more` — bump role label + wallet to the strongest
 // available tokens so low-vision users see the diagram without relying on
 // brand-blue tints. forced-colors is already handled at the token level
@@ -665,6 +730,23 @@
   }
   .hiw__diagWire {
     stroke: var(--text);
+  }
+  .hiw__diagJudgeChipLabel {
+    fill: var(--text);
+  }
+  .hiw__diagJudgeGavel {
+    fill: var(--text);
+  }
+  .hiw__diagJudgeScales {
+    stroke: var(--text);
+  }
+}
+
+// Reduced-motion — drop the dim transition so prefers-reduced-motion users
+// see the final outcome state instantly when Safeguards tabs toggle.
+@media (prefers-reduced-motion: reduce) {
+  .hiw__diagJudgeBody {
+    transition: none;
   }
 }
 

--- a/apps/web/src/features/homepage/HowItWorks/HowItWorks.test.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/HowItWorks.test.tsx
@@ -22,7 +22,7 @@ vi.mock('./HowItWorksAnimations', () => ({
 }));
 
 import { HowItWorks } from './HowItWorks';
-import { HIW_STEPS } from './steps';
+import { HIW_STEPS } from './data';
 
 afterEach(cleanup);
 

--- a/apps/web/src/features/homepage/HowItWorks/HowItWorks.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/HowItWorks.tsx
@@ -6,6 +6,7 @@ import { HiwDiagram } from './HiwDiagram';
 import { HiwPhaseDiagram } from './HiwPhaseDiagram';
 import { HIW_STEPS, LEDGER_LOGS } from './data';
 import { HiwProvider, useHiw } from './context/HiwContext';
+import { SafeguardsPanel } from './Safeguards/SafeguardsPanel';
 import styles from './HowItWorks.module.scss';
 
 const STATE_CLASS: Record<string, string | undefined> = {
@@ -255,6 +256,7 @@ function HowItWorksContent() {
           </nav>
         </div>
       </HowItWorksAnimations>
+      <SafeguardsPanel />
     </section>
   );
 }

--- a/apps/web/src/features/homepage/HowItWorks/HowItWorks.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/HowItWorks.tsx
@@ -4,7 +4,7 @@ import { useRef, useState } from 'react';
 import { HowItWorksAnimations } from './HowItWorksAnimations';
 import { HiwDiagram } from './HiwDiagram';
 import { HiwPhaseDiagram } from './HiwPhaseDiagram';
-import { HIW_STEPS, LEDGER_LOGS } from './steps';
+import { HIW_STEPS, LEDGER_LOGS } from './data';
 import styles from './HowItWorks.module.scss';
 
 const STATE_CLASS: Record<string, string | undefined> = {

--- a/apps/web/src/features/homepage/HowItWorks/HowItWorks.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/HowItWorks.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import { useRef } from 'react';
 import { HowItWorksAnimations } from './HowItWorksAnimations';
 import { HiwDiagram } from './HiwDiagram';
 import { HiwPhaseDiagram } from './HiwPhaseDiagram';
 import { HIW_STEPS, LEDGER_LOGS } from './data';
+import { HiwProvider, useHiw } from './context/HiwContext';
 import styles from './HowItWorks.module.scss';
 
 const STATE_CLASS: Record<string, string | undefined> = {
@@ -16,8 +17,16 @@ const STATE_CLASS: Record<string, string | undefined> = {
 };
 
 export function HowItWorks() {
+  return (
+    <HiwProvider>
+      <HowItWorksContent />
+    </HiwProvider>
+  );
+}
+
+function HowItWorksContent() {
   const stageRef = useRef<HTMLDivElement>(null);
-  const [active, setActive] = useState(0);
+  const { phase: active, setPhase: setActive } = useHiw();
   const step = HIW_STEPS[active]!;
   const stateClass = STATE_CLASS[step.ledger.state] ?? '';
   const progress = ((active + 1) / HIW_STEPS.length) * 100;

--- a/apps/web/src/features/homepage/HowItWorks/HowItWorks.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/HowItWorks.tsx
@@ -6,6 +6,7 @@ import { HiwDiagram } from './HiwDiagram';
 import { HiwPhaseDiagram } from './HiwPhaseDiagram';
 import { HIW_STEPS, LEDGER_LOGS } from './data';
 import { HiwProvider, useHiw } from './context/HiwContext';
+import { useOutcomeBranch } from './animations/useOutcomeBranch';
 import { SafeguardsPanel } from './Safeguards/SafeguardsPanel';
 import styles from './HowItWorks.module.scss';
 
@@ -26,14 +27,17 @@ export function HowItWorks() {
 }
 
 function HowItWorksContent() {
+  const sectionRef = useRef<HTMLElement>(null);
   const stageRef = useRef<HTMLDivElement>(null);
-  const { phase: active, setPhase: setActive } = useHiw();
+  const { phase: active, setPhase: setActive, outcome } = useHiw();
+  useOutcomeBranch({ targetRef: sectionRef, outcome });
   const step = HIW_STEPS[active]!;
   const stateClass = STATE_CLASS[step.ledger.state] ?? '';
   const progress = ((active + 1) / HIW_STEPS.length) * 100;
 
   return (
     <section
+      ref={sectionRef}
       className={`o-section ${styles.hiw}`}
       id="hiw"
       aria-label="How it works in five steps"

--- a/apps/web/src/features/homepage/HowItWorks/HowItWorksAnimations.test.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/HowItWorksAnimations.test.tsx
@@ -13,7 +13,7 @@ import { render, cleanup } from '@testing-library/react';
 import type { RefObject } from 'react';
 
 import { MATCH_MEDIA } from '@/animations/config/defaults';
-import { PHASE_COUNT } from './steps';
+import { PHASE_COUNT } from './data';
 // Type-only import so the mock factory can reference the module's shape
 // without resurrecting a runtime import (which would fight with vi.mock).
 // The @typescript-eslint/consistent-type-imports rule also forbids inline

--- a/apps/web/src/features/homepage/HowItWorks/HowItWorksAnimations.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/HowItWorksAnimations.tsx
@@ -56,7 +56,7 @@ import {
   CORE_POSITION,
   HIW_STEPS,
   type HiwStep,
-} from './steps';
+} from './data';
 import { HIW_EASE_NAMES, registerHiwEases } from './hiw-eases';
 
 // Ensure the eases are registered at module load time (once per JS bundle).

--- a/apps/web/src/features/homepage/HowItWorks/Safeguards/Safeguards.module.scss
+++ b/apps/web/src/features/homepage/HowItWorks/Safeguards/Safeguards.module.scss
@@ -249,6 +249,21 @@
   margin: 24px auto 0;
 }
 
+// Visually-hidden live region — standard WCAG-compliant clip pattern
+// (matches `tools/_a11y.scss .u-visually-hidden`). Screen readers get
+// the outcome announcement; sighted users see nothing.
+.safeguards__liveRegion {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 // prefers-contrast: more — flatten the color-mix treatments to solid
 // tokens so the chip status remains distinguishable under high contrast.
 @media (prefers-contrast: more) {

--- a/apps/web/src/features/homepage/HowItWorks/Safeguards/Safeguards.module.scss
+++ b/apps/web/src/features/homepage/HowItWorks/Safeguards/Safeguards.module.scss
@@ -1,0 +1,266 @@
+@use '../../../../styles/settings/variables' as *;
+@use '../../../../styles/settings/typography' as *;
+
+// ---------------------------------------------------------------------------
+// Safeguards panel — "What if it goes wrong?"
+//
+// Sits directly below the pinned happy-path stage, visible on every
+// breakpoint (desktop + mobile deck both benefit from seeing the
+// non-Delivery resolutions). Colour tokens inherit dark/light theme from
+// the cookie-driven SSR provider via --accent / --bg-surface / --text.
+//
+// Fee pills use --status-success for "fee-free" (client-win paths) and
+// --accent for "fees apply" (seller-win paths) so the cost semantic is
+// scannable without parsing the prose. Both map to readable tokens under
+// forced-colors and prefers-contrast: more.
+// ---------------------------------------------------------------------------
+
+.safeguards {
+  position: relative;
+  padding: clamp(48px, 6vw, 96px) clamp(1.25rem, 4vw, 2.5rem);
+  background: var(--bg-page);
+  border-top: 1px solid var(--border);
+}
+
+.safeguards__head {
+  max-width: 640px;
+  margin: 0 auto 40px;
+  text-align: center;
+}
+
+.safeguards__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--ff-mono);
+  font-size: 12px;
+  line-height: 1;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--accent);
+
+  &::before,
+  &::after {
+    content: '';
+    width: 24px;
+    height: 1px;
+    background: currentColor;
+    opacity: 0.7;
+  }
+}
+
+.safeguards__heading {
+  font-size: clamp(28px, 4vw, 48px);
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  font-weight: 600;
+  margin: 16px 0 12px;
+  text-wrap: balance;
+  color: var(--text);
+
+  em {
+    font-style: italic;
+    font-weight: 400;
+    color: var(--accent);
+  }
+}
+
+.safeguards__subtitle {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 17px;
+  text-wrap: pretty;
+}
+
+// --- Tabs -------------------------------------------------------------------
+
+.safeguards__tabs {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  max-width: 1100px;
+  margin: 0 auto 32px;
+
+  // Tablet: 2x2 grid
+  @media (max-width: 900px) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  // Mobile: horizontal scroll-snap so all four chips stay reachable
+  // without stacking vertically (keeps the comparison affordance).
+  @media (max-width: 560px) {
+    grid-template-columns: none;
+    display: flex;
+    gap: 10px;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    scroll-padding-inline: 16px;
+    padding-block-end: 8px; // room for scrollbar on mobile Safari
+    touch-action: pan-x;
+
+    > * {
+      flex: 0 0 80%;
+      scroll-snap-align: center;
+    }
+  }
+}
+
+.safeguards__tab {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 18px 20px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: var(--bg-surface);
+  color: var(--text);
+  font-family: var(--ff-sans);
+  font-size: 16px;
+  font-weight: 500;
+  text-align: start;
+  cursor: pointer;
+  transition:
+    border-color 0.25s var(--ease-out-expo),
+    background 0.25s var(--ease-out-expo),
+    transform 0.25s var(--ease-out-expo);
+
+  &:hover {
+    border-color: var(--accent);
+    transform: translateY(-2px);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+    &:hover {
+      transform: none;
+    }
+  }
+}
+
+.safeguards__tab--active {
+  border-color: var(--accent);
+  background: color-mix(in oklch, var(--accent) 12%, var(--bg-surface));
+  box-shadow: 0 0 0 1px var(--accent);
+}
+
+.safeguards__tabLabel {
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.safeguards__tabFee {
+  font-family: var(--ff-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 3px 8px;
+  border-radius: 999px;
+  line-height: 1;
+}
+
+.safeguards__tabFee--paid {
+  background: color-mix(in oklch, var(--accent) 14%, transparent);
+  color: var(--accent);
+}
+
+.safeguards__tabFee--free {
+  background: color-mix(in oklch, var(--status-success, #22cc66) 14%, transparent);
+  color: var(--status-success, #22cc66);
+}
+
+// --- Panels -----------------------------------------------------------------
+
+.safeguards__panels {
+  max-width: 720px;
+  margin: 0 auto;
+  min-height: 180px;
+}
+
+.safeguards__panel {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: clamp(24px, 3vw, 36px);
+
+  &[hidden] {
+    display: none;
+  }
+}
+
+.safeguards__panelTitle {
+  font-size: clamp(20px, 2.4vw, 28px);
+  line-height: 1.15;
+  letter-spacing: -0.01em;
+  font-weight: 600;
+  margin: 0 0 12px;
+  color: var(--text);
+}
+
+.safeguards__panelBody {
+  margin: 0 0 20px;
+  color: var(--text-muted);
+  font-size: 16px;
+  line-height: 1.55;
+  text-wrap: pretty;
+}
+
+.safeguards__feeNote {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0;
+  padding: 8px 14px;
+  border-radius: 999px;
+  font-family: var(--ff-mono);
+  font-size: 13px;
+  letter-spacing: 0.02em;
+}
+
+.safeguards__feeNote--paid {
+  background: color-mix(in oklch, var(--accent) 10%, transparent);
+  color: var(--accent);
+}
+
+.safeguards__feeNote--free {
+  background: color-mix(in oklch, var(--status-success, #22cc66) 10%, transparent);
+  color: var(--status-success, #22cc66);
+}
+
+.safeguards__feeDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.safeguards__hint {
+  text-align: center;
+  color: var(--text-muted);
+  font-family: var(--ff-mono);
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  margin: 24px auto 0;
+}
+
+// prefers-contrast: more — flatten the color-mix treatments to solid
+// tokens so the chip status remains distinguishable under high contrast.
+@media (prefers-contrast: more) {
+  .safeguards__tabFee--paid,
+  .safeguards__feeNote--paid {
+    background: var(--accent-soft, var(--bg-surface));
+    color: var(--text);
+  }
+  .safeguards__tabFee--free,
+  .safeguards__feeNote--free {
+    background: var(--bg-surface);
+    color: var(--text);
+    outline: 1px solid var(--status-success, var(--accent));
+  }
+}

--- a/apps/web/src/features/homepage/HowItWorks/Safeguards/SafeguardsPanel.test.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/Safeguards/SafeguardsPanel.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup, fireEvent, within } from '@testing-library/react';
+import { HiwProvider } from '../context/HiwContext';
+import { SafeguardsPanel } from './SafeguardsPanel';
+
+afterEach(cleanup);
+
+function renderWithProvider() {
+  return render(
+    <HiwProvider>
+      <SafeguardsPanel />
+    </HiwProvider>,
+  );
+}
+
+describe('SafeguardsPanel — tablist contract', () => {
+  it('renders exactly four tabs for the four Safeguards outcomes', () => {
+    const { container } = renderWithProvider();
+    const tablist = container.querySelector('[role="tablist"]');
+    expect(tablist).not.toBeNull();
+    const tabs = container.querySelectorAll('[role="tab"]');
+    expect(tabs.length).toBe(4);
+  });
+
+  it('tags each tab with data-hiw-outcome-chip keyed by outcome id', () => {
+    const { container } = renderWithProvider();
+    const ids = Array.from(
+      container.querySelectorAll('[data-hiw-outcome-chip]'),
+    ).map((el) => el.getAttribute('data-hiw-outcome-chip'));
+    expect(new Set(ids)).toEqual(
+      new Set(['refund', 'disputeBuyer', 'disputeSeller', 'timeout']),
+    );
+  });
+
+  it('starts with no tab selected (happy-path default outcome=null)', () => {
+    const { container } = renderWithProvider();
+    for (const tab of container.querySelectorAll('[role="tab"]')) {
+      expect(tab.getAttribute('aria-selected')).toBe('false');
+    }
+  });
+
+  it('clicking a tab flips aria-selected and reveals the matching tabpanel', () => {
+    const { container } = renderWithProvider();
+    const refundTab = container.querySelector<HTMLButtonElement>(
+      '[data-hiw-outcome-chip="refund"]',
+    )!;
+    fireEvent.click(refundTab);
+    expect(refundTab.getAttribute('aria-selected')).toBe('true');
+
+    const refundPanel = container.querySelector<HTMLElement>(
+      '[data-hiw-outcome-panel="refund"]',
+    )!;
+    expect(refundPanel.hasAttribute('hidden')).toBe(false);
+
+    // All other panels stay hidden
+    const others = container.querySelectorAll(
+      '[data-hiw-outcome-panel]:not([data-hiw-outcome-panel="refund"])',
+    );
+    for (const p of others) {
+      expect(p.hasAttribute('hidden')).toBe(true);
+    }
+  });
+
+  it('re-clicking the active tab returns to happy-path (outcome=null, all panels hidden)', () => {
+    const { container } = renderWithProvider();
+    const refundTab = container.querySelector<HTMLButtonElement>(
+      '[data-hiw-outcome-chip="refund"]',
+    )!;
+    fireEvent.click(refundTab);
+    fireEvent.click(refundTab);
+    expect(refundTab.getAttribute('aria-selected')).toBe('false');
+    for (const panel of container.querySelectorAll('[data-hiw-outcome-panel]')) {
+      expect(panel.hasAttribute('hidden')).toBe(true);
+    }
+  });
+
+  it('colour-codes fee badges: dispute-seller pays, the other three are fee-free', () => {
+    const { container } = renderWithProvider();
+    const chipFee = (id: string) =>
+      container
+        .querySelector(`[data-hiw-outcome-chip="${id}"]`)
+        ?.querySelector('[aria-hidden="true"]')?.textContent;
+    expect(chipFee('disputeSeller')).toMatch(/Fees apply/i);
+    expect(chipFee('refund')).toMatch(/Fee-free/i);
+    expect(chipFee('disputeBuyer')).toMatch(/Fee-free/i);
+    expect(chipFee('timeout')).toMatch(/Fee-free/i);
+  });
+
+  it('exposes a semantic heading and subtitle via aria-labelledby', () => {
+    const { container } = renderWithProvider();
+    const section = container.querySelector('section[aria-labelledby]');
+    expect(section).not.toBeNull();
+    const headingId = section!.getAttribute('aria-labelledby')!;
+    // `useId()` can produce ids containing `:`; fetch by getElementById to
+    // side-step querySelector's need for CSS.escape (absent in jsdom).
+    const heading = document.getElementById(headingId);
+    expect(heading).not.toBeNull();
+    expect(heading?.tagName.toLowerCase()).toBe('h3');
+    expect(heading?.textContent).toMatch(/goes wrong/i);
+  });
+
+  it('only the active tab is in the tab order (tabIndex=0); others get -1', () => {
+    const { container } = renderWithProvider();
+    // At rest every tab is non-active; the first tab still needs a keyboard
+    // entry point per APG but we use -1 for all inactive tabs and rely on
+    // outer container focus. Once any tab is active, it owns tabIndex 0.
+    const refundTab = container.querySelector<HTMLButtonElement>(
+      '[data-hiw-outcome-chip="refund"]',
+    )!;
+    fireEvent.click(refundTab);
+    expect(refundTab.tabIndex).toBe(0);
+    const others = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('[data-hiw-outcome-chip]'),
+    ).filter((el) => el !== refundTab);
+    for (const t of others) {
+      expect(t.tabIndex).toBe(-1);
+    }
+  });
+});

--- a/apps/web/src/features/homepage/HowItWorks/Safeguards/SafeguardsPanel.test.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/Safeguards/SafeguardsPanel.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { render, cleanup, fireEvent, within } from '@testing-library/react';
 import { HiwProvider } from '../context/HiwContext';
-import { SafeguardsPanel } from './SafeguardsPanel';
+import { SafeguardsPanel, announceOutcome } from './SafeguardsPanel';
 
 afterEach(cleanup);
 
@@ -99,6 +99,24 @@ describe('SafeguardsPanel — tablist contract', () => {
     expect(heading?.textContent).toMatch(/goes wrong/i);
   });
 
+  it('exposes a polite aria-live region that updates on outcome change', () => {
+    const { container } = renderWithProvider();
+    const live = container.querySelector('[data-hiw-outcome-announcer]');
+    expect(live).not.toBeNull();
+    expect(live?.getAttribute('aria-live')).toBe('polite');
+    expect(live?.getAttribute('aria-atomic')).toBe('true');
+    expect(live?.getAttribute('role')).toBe('status');
+    // happy-path announcement present at mount
+    expect(live?.textContent).toMatch(/happy path/i);
+
+    const refundTab = container.querySelector<HTMLButtonElement>(
+      '[data-hiw-outcome-chip="refund"]',
+    )!;
+    fireEvent.click(refundTab);
+    expect(live?.textContent).toMatch(/refund/i);
+    expect(live?.textContent).toMatch(/seller accepts/i);
+  });
+
   it('only the active tab is in the tab order (tabIndex=0); others get -1', () => {
     const { container } = renderWithProvider();
     // At rest every tab is non-active; the first tab still needs a keyboard
@@ -114,6 +132,25 @@ describe('SafeguardsPanel — tablist contract', () => {
     ).filter((el) => el !== refundTab);
     for (const t of others) {
       expect(t.tabIndex).toBe(-1);
+    }
+  });
+});
+
+describe('announceOutcome helper', () => {
+  it('returns happy-path phrase when outcome is null', () => {
+    expect(announceOutcome(null)).toMatch(/happy path/i);
+  });
+
+  it('reads out the chip label, title, and fee note for a named outcome', () => {
+    const msg = announceOutcome('disputeSeller');
+    expect(msg).toMatch(/Dispute/i);
+    expect(msg).toMatch(/Seller/i);
+    expect(msg).toMatch(/Fees apply/i);
+  });
+
+  it('includes chip label for every one of the four Safeguards outcomes', () => {
+    for (const id of ['refund', 'disputeBuyer', 'disputeSeller', 'timeout']) {
+      expect(announceOutcome(id)).toBeTruthy();
     }
   });
 });

--- a/apps/web/src/features/homepage/HowItWorks/Safeguards/SafeguardsPanel.test.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/Safeguards/SafeguardsPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { render, cleanup, fireEvent, within } from '@testing-library/react';
+import { render, cleanup, fireEvent } from '@testing-library/react';
 import { HiwProvider } from '../context/HiwContext';
 import { SafeguardsPanel, announceOutcome } from './SafeguardsPanel';
 

--- a/apps/web/src/features/homepage/HowItWorks/Safeguards/SafeguardsPanel.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/Safeguards/SafeguardsPanel.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+/**
+ * Safeguards · What if it goes wrong?
+ *
+ * Four-tab panel that sits directly under the pinned happy-path stage.
+ * Each tab corresponds to one non-Delivery `ResolutionType` in
+ * `Escrow.sol`:
+ *
+ *   - Refund           · seller accepts refund (ResolutionType.Refund)
+ *   - Dispute → Buyer  · middleman sides with client (MiddlemanBuyer)
+ *   - Dispute → Seller · middleman sides with seller (MiddlemanSeller)
+ *   - Timeout          · permissionless executeTimeout after deadline
+ *
+ * Clicking a chip toggles the outcome in `HiwContext`. A second click
+ * on the active chip returns to happy-path (outcome=null) — this keeps
+ * the tablist keyboard-friendly without requiring a separate "back to
+ * happy path" affordance. Each tabpanel carries the canonical
+ * `role="tabpanel"` + `aria-labelledby` + `hidden` contract so screen
+ * readers ignore the three inactive panels entirely.
+ *
+ * Fee-note rendering colour-codes seller-win branches (ResolutionType
+ * Delivery + MiddlemanSeller → fees apply) vs client-win (Refund,
+ * MiddlemanBuyer, Timeout → no fees). The chip copy comes from
+ * `data/outcomes.ts` which is the single source of truth the unit
+ * tests guard against Solidity drift.
+ */
+
+import { useId } from 'react';
+import { HIW_OUTCOMES } from '../data/outcomes';
+import { useHiw } from '../context/HiwContext';
+import styles from './Safeguards.module.scss';
+
+export function SafeguardsPanel() {
+  const { outcome, setOutcome } = useHiw();
+  const baseId = useId();
+
+  return (
+    <section
+      className={styles.safeguards}
+      aria-labelledby={`${baseId}-heading`}
+    >
+      <header className={styles.safeguards__head}>
+        <div className={styles.safeguards__eyebrow}>Safeguards</div>
+        <h3 id={`${baseId}-heading`} className={styles.safeguards__heading}>
+          What if it <em>goes wrong?</em>
+        </h3>
+        <p className={styles.safeguards__subtitle}>
+          The happy path above is one of five on-chain resolutions. Pick a
+          branch to see how the contract handles each one — without the
+          middleman ever touching a dollar.
+        </p>
+      </header>
+
+      <div
+        className={styles.safeguards__tabs}
+        role="tablist"
+        aria-label="Safeguard outcomes"
+      >
+        {HIW_OUTCOMES.map((o) => {
+          const isActive = outcome === o.id;
+          return (
+            <button
+              key={o.id}
+              type="button"
+              role="tab"
+              id={`${baseId}-tab-${o.id}`}
+              aria-controls={`${baseId}-panel-${o.id}`}
+              aria-selected={isActive}
+              tabIndex={isActive ? 0 : -1}
+              data-hiw-outcome-chip={o.id}
+              className={`${styles.safeguards__tab} ${
+                isActive ? styles['safeguards__tab--active'] : ''
+              }`}
+              onClick={() => setOutcome(isActive ? null : o.id)}
+            >
+              <span className={styles.safeguards__tabLabel}>{o.chipLabel}</span>
+              <span
+                className={`${styles.safeguards__tabFee} ${
+                  o.feeApplies
+                    ? styles['safeguards__tabFee--paid']
+                    : styles['safeguards__tabFee--free']
+                }`}
+                aria-hidden="true"
+              >
+                {o.feeApplies ? 'Fees apply' : 'Fee-free'}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className={styles.safeguards__panels}>
+        {HIW_OUTCOMES.map((o) => {
+          const isActive = outcome === o.id;
+          return (
+            <section
+              key={o.id}
+              role="tabpanel"
+              id={`${baseId}-panel-${o.id}`}
+              aria-labelledby={`${baseId}-tab-${o.id}`}
+              hidden={!isActive}
+              className={styles.safeguards__panel}
+              data-hiw-outcome-panel={o.id}
+            >
+              <h4 className={styles.safeguards__panelTitle}>{o.narrTitle}</h4>
+              <p className={styles.safeguards__panelBody}>{o.narrBody}</p>
+              <p
+                className={`${styles.safeguards__feeNote} ${
+                  o.feeApplies
+                    ? styles['safeguards__feeNote--paid']
+                    : styles['safeguards__feeNote--free']
+                }`}
+              >
+                <span aria-hidden="true" className={styles.safeguards__feeDot} />
+                {o.feeNote}
+              </p>
+            </section>
+          );
+        })}
+      </div>
+
+      {outcome === null ? (
+        <p className={styles.safeguards__hint} aria-live="polite">
+          Pick a branch above to preview its on-chain resolution.
+        </p>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/features/homepage/HowItWorks/Safeguards/SafeguardsPanel.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/Safeguards/SafeguardsPanel.tsx
@@ -27,9 +27,22 @@
  */
 
 import { useId } from 'react';
-import { HIW_OUTCOMES } from '../data/outcomes';
+import { HIW_OUTCOMES, getOutcome } from '../data/outcomes';
 import { useHiw } from '../context/HiwContext';
 import styles from './Safeguards.module.scss';
+
+/**
+ * Announcement string for a given outcome id — used by the visually-
+ * hidden aria-live region. Keeping it in a pure helper lets the unit
+ * test assert the exact phrasing without reaching into the JSX.
+ */
+export function announceOutcome(outcomeId: string | null): string {
+  if (!outcomeId) {
+    return 'Safeguards panel closed. Happy path active.';
+  }
+  const outcome = getOutcome(outcomeId as never);
+  return `${outcome.chipLabel} outcome selected. ${outcome.narrTitle} ${outcome.feeNote}.`;
+}
 
 export function SafeguardsPanel() {
   const { outcome, setOutcome } = useHiw();
@@ -121,10 +134,28 @@ export function SafeguardsPanel() {
       </div>
 
       {outcome === null ? (
-        <p className={styles.safeguards__hint} aria-live="polite">
+        <p className={styles.safeguards__hint}>
           Pick a branch above to preview its on-chain resolution.
         </p>
       ) : null}
+
+      {/*
+       * Dedicated, visually-hidden aria-live region. Placing the
+       * announcement on its own polite channel (separate from the
+       * hint paragraph) means screen readers announce *every*
+       * outcome change, not just the first transition away from
+       * happy path. aria-atomic="true" forces the full phrase to be
+       * read on each change instead of just the diff.
+       */}
+      <div
+        className={styles.safeguards__liveRegion}
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        data-hiw-outcome-announcer
+      >
+        {announceOutcome(outcome)}
+      </div>
     </section>
   );
 }

--- a/apps/web/src/features/homepage/HowItWorks/animations/useOutcomeBranch.test.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/animations/useOutcomeBranch.test.tsx
@@ -45,6 +45,40 @@ describe('useOutcomeBranch', () => {
     }
   });
 
+  it('charges the vault on every outcome (Safeguards fires post-Fund)', () => {
+    const outcomes: Array<OutcomeId | null> = [
+      null,
+      'refund',
+      'disputeBuyer',
+      'disputeSeller',
+      'timeout',
+    ];
+    for (const outcome of outcomes) {
+      const { getByTestId, unmount } = render(<Harness outcome={outcome} />);
+      expect(
+        getByTestId('target').style.getPropertyValue('--hiw-vault-charge'),
+      ).toBe('1');
+      unmount();
+    }
+  });
+
+  it('flags --hiw-fee-applies to match Solidity: only Delivery + MiddlemanSeller pay fees', () => {
+    const cases: Array<[OutcomeId | null, string]> = [
+      [null, '1'], // happy path = Delivery
+      ['refund', '0'],
+      ['disputeBuyer', '0'],
+      ['disputeSeller', '1'],
+      ['timeout', '0'],
+    ];
+    for (const [outcome, expected] of cases) {
+      const { getByTestId, unmount } = render(<Harness outcome={outcome} />);
+      expect(
+        getByTestId('target').style.getPropertyValue('--hiw-fee-applies'),
+      ).toBe(expected);
+      unmount();
+    }
+  });
+
   it('clears attribute + styles on unmount', () => {
     const { getByTestId, unmount } = render(<Harness outcome="disputeBuyer" />);
     const el = getByTestId('target');

--- a/apps/web/src/features/homepage/HowItWorks/animations/useOutcomeBranch.test.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/animations/useOutcomeBranch.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { createRef, useRef } from 'react';
+import { render, cleanup } from '@testing-library/react';
+import { useOutcomeBranch } from './useOutcomeBranch';
+import type { OutcomeId } from '../data/outcomes';
+
+afterEach(cleanup);
+
+function Harness({ outcome }: { outcome: OutcomeId | null }) {
+  const ref = useRef<HTMLDivElement>(null);
+  useOutcomeBranch({ targetRef: ref, outcome });
+  return <div ref={ref} data-testid="target" />;
+}
+
+describe('useOutcomeBranch', () => {
+  it('writes data-hiw-outcome="happy" when outcome is null', () => {
+    const { getByTestId } = render(<Harness outcome={null} />);
+    const el = getByTestId('target');
+    expect(el.getAttribute('data-hiw-outcome')).toBe('happy');
+  });
+
+  it('writes the outcome id when a Safeguards branch is active', () => {
+    const { getByTestId, rerender } = render(<Harness outcome="disputeBuyer" />);
+    const el = getByTestId('target');
+    expect(el.getAttribute('data-hiw-outcome')).toBe('disputeBuyer');
+    rerender(<Harness outcome="timeout" />);
+    expect(el.getAttribute('data-hiw-outcome')).toBe('timeout');
+  });
+
+  it('lifts --hiw-judge-opacity to 1 on disputeBuyer and disputeSeller', () => {
+    const { getByTestId, rerender } = render(<Harness outcome="disputeBuyer" />);
+    const el = getByTestId('target');
+    expect(el.style.getPropertyValue('--hiw-judge-opacity')).toBe('1');
+    rerender(<Harness outcome="disputeSeller" />);
+    expect(el.style.getPropertyValue('--hiw-judge-opacity')).toBe('1');
+  });
+
+  it('keeps --hiw-judge-opacity at 0.3 on fee-free / non-dispute outcomes', () => {
+    const outcomes: Array<OutcomeId | null> = [null, 'refund', 'timeout'];
+    for (const outcome of outcomes) {
+      const { getByTestId, unmount } = render(<Harness outcome={outcome} />);
+      const el = getByTestId('target');
+      expect(el.style.getPropertyValue('--hiw-judge-opacity')).toBe('0.3');
+      unmount();
+    }
+  });
+
+  it('clears attribute + styles on unmount', () => {
+    const { getByTestId, unmount } = render(<Harness outcome="disputeBuyer" />);
+    const el = getByTestId('target');
+    expect(el.getAttribute('data-hiw-outcome')).toBe('disputeBuyer');
+    expect(el.style.getPropertyValue('--hiw-judge-opacity')).toBe('1');
+    unmount();
+    // After unmount the element is removed from the DOM; if it were still
+    // attached, the cleanup effect would have wiped attribute + style — we
+    // assert that by rendering a fresh mount with a different outcome.
+    const { getByTestId: getFresh } = render(<Harness outcome={null} />);
+    expect(getFresh('target').getAttribute('data-hiw-outcome')).toBe('happy');
+  });
+
+  it('no-ops when the ref has no element yet (SSR pre-hydration)', () => {
+    // Fabricate a ref that never attaches — simulates a premature call.
+    const ref = createRef<HTMLDivElement>();
+    // Direct invocation harness
+    function Fake() {
+      useOutcomeBranch({ targetRef: ref, outcome: 'timeout' });
+      return null;
+    }
+    expect(() => render(<Fake />)).not.toThrow();
+  });
+});

--- a/apps/web/src/features/homepage/HowItWorks/animations/useOutcomeBranch.ts
+++ b/apps/web/src/features/homepage/HowItWorks/animations/useOutcomeBranch.ts
@@ -36,6 +36,10 @@ interface OutcomeVars {
   '--hiw-vault-charge'?: number;
   /** Numeric flag consumed by CSS: 1 if fees are deducted, 0 if fee-free. */
   '--hiw-fee-applies'?: number;
+  /** Numeric flag consumed by CSS: 1 if any Safeguards branch is active. */
+  '--hiw-outcome-active'?: number;
+  /** 1 when a dispute resolution mints a soulbound NFT to the middleman. */
+  '--hiw-soulbound-mint'?: number;
 }
 
 /**
@@ -53,26 +57,36 @@ const OUTCOME_VARS: Record<OutcomeKey, OutcomeVars> = {
     '--hiw-judge-opacity': 0.3,
     '--hiw-vault-charge': 1,
     '--hiw-fee-applies': 1, // Delivery → fees apply
+    '--hiw-outcome-active': 0, // happy path = default scroll narrative
+    '--hiw-soulbound-mint': 0, // no middleman vote on happy path
   },
   refund: {
     '--hiw-judge-opacity': 0.3,
     '--hiw-vault-charge': 1,
     '--hiw-fee-applies': 0, // no fees — seller volunteered refund
+    '--hiw-outcome-active': 1,
+    '--hiw-soulbound-mint': 0,
   },
   disputeBuyer: {
     '--hiw-judge-opacity': 1,
     '--hiw-vault-charge': 1,
     '--hiw-fee-applies': 0, // buyer protection — no fees
+    '--hiw-outcome-active': 1,
+    '--hiw-soulbound-mint': 1, // middleman ruled → soulbound receipt
   },
   disputeSeller: {
     '--hiw-judge-opacity': 1,
     '--hiw-vault-charge': 1,
     '--hiw-fee-applies': 1, // same split as delivery
+    '--hiw-outcome-active': 1,
+    '--hiw-soulbound-mint': 1,
   },
   timeout: {
     '--hiw-judge-opacity': 0.3,
     '--hiw-vault-charge': 1,
     '--hiw-fee-applies': 0, // permissionless rescue — no fees
+    '--hiw-outcome-active': 1,
+    '--hiw-soulbound-mint': 0,
   },
 };
 
@@ -80,6 +94,8 @@ const TRACKED_VARS = [
   '--hiw-judge-opacity',
   '--hiw-vault-charge',
   '--hiw-fee-applies',
+  '--hiw-outcome-active',
+  '--hiw-soulbound-mint',
 ] as const;
 
 export interface UseOutcomeBranchParams {

--- a/apps/web/src/features/homepage/HowItWorks/animations/useOutcomeBranch.ts
+++ b/apps/web/src/features/homepage/HowItWorks/animations/useOutcomeBranch.ts
@@ -1,0 +1,79 @@
+'use client';
+
+/**
+ * useOutcomeBranch — outcome-reactive CSS bridge.
+ *
+ * Listens to `HiwContext.outcome` and, when the user picks a Safeguards
+ * tab, writes a single `data-hiw-outcome` attribute + a handful of CSS
+ * custom properties on a target element (the HowItWorks <section>).
+ * Styles in the SVG module (hiw-svg.module.scss) and the main module
+ * (HowItWorks.module.scss) drive the visual response off those
+ * properties, so the branch effect lands without touching the existing
+ * 879-line master timeline.
+ *
+ * CSS vars written:
+ *   --hiw-judge-opacity   · 1 on dispute outcomes (middleman activates),
+ *                           0.3 otherwise (happy-path standby)
+ *   --hiw-vault-charge    · 0 pre-Fund / refund / timeout,
+ *                           1 post-Fund / Settle paths (kept at 0 for
+ *                           now — commit 9-11 ramps it per branch)
+ *
+ * Future commits (dispute/timeout/refund timelines) can extend the
+ * `outcomeVars` map without touching any consumer.
+ *
+ * The hook is a strict function-of-state: no refs, no timers, safe to
+ * re-run on every context transition. Reduced-motion users get the same
+ * final values — the CSS layer handles instant vs transitioned paint.
+ */
+
+import { useEffect, type RefObject } from 'react';
+import type { OutcomeId } from '../data/outcomes';
+
+export type OutcomeKey = OutcomeId | 'happy';
+
+interface OutcomeVars {
+  '--hiw-judge-opacity'?: number;
+  '--hiw-vault-charge'?: number;
+}
+
+const OUTCOME_VARS: Record<OutcomeKey, OutcomeVars> = {
+  happy: { '--hiw-judge-opacity': 0.3 },
+  refund: { '--hiw-judge-opacity': 0.3 },
+  disputeBuyer: { '--hiw-judge-opacity': 1 },
+  disputeSeller: { '--hiw-judge-opacity': 1 },
+  timeout: { '--hiw-judge-opacity': 0.3 },
+};
+
+const TRACKED_VARS = ['--hiw-judge-opacity', '--hiw-vault-charge'] as const;
+
+export interface UseOutcomeBranchParams {
+  targetRef: RefObject<HTMLElement | null>;
+  outcome: OutcomeId | null;
+}
+
+export function useOutcomeBranch({ targetRef, outcome }: UseOutcomeBranchParams) {
+  useEffect(() => {
+    const target = targetRef.current;
+    if (!target) return;
+
+    const key: OutcomeKey = outcome ?? 'happy';
+    target.setAttribute('data-hiw-outcome', key);
+
+    const vars = OUTCOME_VARS[key] ?? {};
+    for (const name of TRACKED_VARS) {
+      const value = vars[name];
+      if (value === undefined) {
+        target.style.removeProperty(name);
+      } else {
+        target.style.setProperty(name, String(value));
+      }
+    }
+
+    return () => {
+      target.removeAttribute('data-hiw-outcome');
+      for (const name of TRACKED_VARS) {
+        target.style.removeProperty(name);
+      }
+    };
+  }, [targetRef, outcome]);
+}

--- a/apps/web/src/features/homepage/HowItWorks/animations/useOutcomeBranch.ts
+++ b/apps/web/src/features/homepage/HowItWorks/animations/useOutcomeBranch.ts
@@ -34,17 +34,53 @@ export type OutcomeKey = OutcomeId | 'happy';
 interface OutcomeVars {
   '--hiw-judge-opacity'?: number;
   '--hiw-vault-charge'?: number;
+  /** Numeric flag consumed by CSS: 1 if fees are deducted, 0 if fee-free. */
+  '--hiw-fee-applies'?: number;
 }
 
+/**
+ * The reactive driver for all five surface states. Every outcome
+ * preserves the vault as charged (--hiw-vault-charge: 1) because funding
+ * has already happened by the time Safeguards fires — the branch story
+ * is about how the vault pays OUT, not whether it was filled.
+ *
+ * --hiw-fee-applies is boolean-as-number so the CSS layer can gate
+ * fee-split visuals (buckets + spouts) without re-deriving the
+ * resolutionAppliesFees rule, and so forced-colors falls back cleanly.
+ */
 const OUTCOME_VARS: Record<OutcomeKey, OutcomeVars> = {
-  happy: { '--hiw-judge-opacity': 0.3 },
-  refund: { '--hiw-judge-opacity': 0.3 },
-  disputeBuyer: { '--hiw-judge-opacity': 1 },
-  disputeSeller: { '--hiw-judge-opacity': 1 },
-  timeout: { '--hiw-judge-opacity': 0.3 },
+  happy: {
+    '--hiw-judge-opacity': 0.3,
+    '--hiw-vault-charge': 1,
+    '--hiw-fee-applies': 1, // Delivery → fees apply
+  },
+  refund: {
+    '--hiw-judge-opacity': 0.3,
+    '--hiw-vault-charge': 1,
+    '--hiw-fee-applies': 0, // no fees — seller volunteered refund
+  },
+  disputeBuyer: {
+    '--hiw-judge-opacity': 1,
+    '--hiw-vault-charge': 1,
+    '--hiw-fee-applies': 0, // buyer protection — no fees
+  },
+  disputeSeller: {
+    '--hiw-judge-opacity': 1,
+    '--hiw-vault-charge': 1,
+    '--hiw-fee-applies': 1, // same split as delivery
+  },
+  timeout: {
+    '--hiw-judge-opacity': 0.3,
+    '--hiw-vault-charge': 1,
+    '--hiw-fee-applies': 0, // permissionless rescue — no fees
+  },
 };
 
-const TRACKED_VARS = ['--hiw-judge-opacity', '--hiw-vault-charge'] as const;
+const TRACKED_VARS = [
+  '--hiw-judge-opacity',
+  '--hiw-vault-charge',
+  '--hiw-fee-applies',
+] as const;
 
 export interface UseOutcomeBranchParams {
   targetRef: RefObject<HTMLElement | null>;

--- a/apps/web/src/features/homepage/HowItWorks/animations/useOutcomeBranch.ts
+++ b/apps/web/src/features/homepage/HowItWorks/animations/useOutcomeBranch.ts
@@ -58,21 +58,21 @@ const OUTCOME_VARS: Record<OutcomeKey, OutcomeVars> = {
     '--hiw-vault-charge': 1,
     '--hiw-fee-applies': 1, // Delivery → fees apply
     '--hiw-outcome-active': 0, // happy path = default scroll narrative
-    '--hiw-soulbound-mint': 0, // no middleman vote on happy path
+    '--hiw-soulbound-mint': 1, // _resolveDeal always mints (Escrow.sol:601)
   },
   refund: {
     '--hiw-judge-opacity': 0.3,
     '--hiw-vault-charge': 1,
     '--hiw-fee-applies': 0, // no fees — seller volunteered refund
     '--hiw-outcome-active': 1,
-    '--hiw-soulbound-mint': 0,
+    '--hiw-soulbound-mint': 1,
   },
   disputeBuyer: {
     '--hiw-judge-opacity': 1,
     '--hiw-vault-charge': 1,
     '--hiw-fee-applies': 0, // buyer protection — no fees
     '--hiw-outcome-active': 1,
-    '--hiw-soulbound-mint': 1, // middleman ruled → soulbound receipt
+    '--hiw-soulbound-mint': 1,
   },
   disputeSeller: {
     '--hiw-judge-opacity': 1,
@@ -86,7 +86,7 @@ const OUTCOME_VARS: Record<OutcomeKey, OutcomeVars> = {
     '--hiw-vault-charge': 1,
     '--hiw-fee-applies': 0, // permissionless rescue — no fees
     '--hiw-outcome-active': 1,
-    '--hiw-soulbound-mint': 0,
+    '--hiw-soulbound-mint': 1,
   },
 };
 

--- a/apps/web/src/features/homepage/HowItWorks/context/HiwContext.test.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/context/HiwContext.test.tsx
@@ -8,11 +8,13 @@ afterEach(cleanup);
 function wrap(
   initial?: { phase?: 0 | 1 | 2 | 3 | 4; outcome?: 'refund' | null },
 ) {
-  return ({ children }: { children: ReactNode }) => (
+  const Wrapper = ({ children }: { children: ReactNode }) => (
     <HiwProvider initialPhase={initial?.phase} initialOutcome={initial?.outcome}>
       {children}
     </HiwProvider>
   );
+  Wrapper.displayName = 'TestHiwProviderWrapper';
+  return Wrapper;
 }
 
 describe('useHiw', () => {

--- a/apps/web/src/features/homepage/HowItWorks/context/HiwContext.test.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/context/HiwContext.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { act, render, cleanup, renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { HiwProvider, useHiw } from './HiwContext';
+
+afterEach(cleanup);
+
+function wrap(
+  initial?: { phase?: 0 | 1 | 2 | 3 | 4; outcome?: 'refund' | null },
+) {
+  return ({ children }: { children: ReactNode }) => (
+    <HiwProvider initialPhase={initial?.phase} initialOutcome={initial?.outcome}>
+      {children}
+    </HiwProvider>
+  );
+}
+
+describe('useHiw', () => {
+  it('throws when consumed outside the provider', () => {
+    // Avoid cluttering the test output with React error boundary logs
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => renderHook(() => useHiw())).toThrow(
+      /useHiw must be used inside/,
+    );
+    err.mockRestore();
+  });
+
+  it('defaults phase=0 and outcome=null (happy path default)', () => {
+    const { result } = renderHook(() => useHiw(), { wrapper: wrap() });
+    expect(result.current.phase).toBe(0);
+    expect(result.current.outcome).toBeNull();
+  });
+
+  it('respects initial values when provided', () => {
+    const { result } = renderHook(() => useHiw(), {
+      wrapper: wrap({ phase: 2, outcome: 'refund' }),
+    });
+    expect(result.current.phase).toBe(2);
+    expect(result.current.outcome).toBe('refund');
+  });
+
+  it('setPhase transitions happy-path position', () => {
+    const { result } = renderHook(() => useHiw(), { wrapper: wrap() });
+    act(() => result.current.setPhase(3));
+    expect(result.current.phase).toBe(3);
+  });
+
+  it('setOutcome toggles the Safeguards branch (null reverts to happy path)', () => {
+    const { result } = renderHook(() => useHiw(), { wrapper: wrap() });
+    act(() => result.current.setOutcome('disputeSeller'));
+    expect(result.current.outcome).toBe('disputeSeller');
+    act(() => result.current.setOutcome(null));
+    expect(result.current.outcome).toBeNull();
+  });
+});
+
+describe('reducedMotion mirroring', () => {
+  const ORIGINAL_MATCH_MEDIA = window.matchMedia;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    window.matchMedia = ORIGINAL_MATCH_MEDIA;
+  });
+
+  it('reports true when prefers-reduced-motion is set', async () => {
+    const listeners = new Set<(e: MediaQueryListEvent) => void>();
+    const mq = {
+      matches: true,
+      media: '(prefers-reduced-motion: reduce)',
+      addEventListener: (_: string, fn: (e: MediaQueryListEvent) => void) =>
+        listeners.add(fn),
+      removeEventListener: (_: string, fn: (e: MediaQueryListEvent) => void) =>
+        listeners.delete(fn),
+      addListener: (fn: (e: MediaQueryListEvent) => void) => listeners.add(fn),
+      removeListener: (fn: (e: MediaQueryListEvent) => void) =>
+        listeners.delete(fn),
+      onchange: null,
+      dispatchEvent: () => true,
+    } as unknown as MediaQueryList;
+
+    window.matchMedia = vi.fn().mockReturnValue(mq);
+
+    const { result } = renderHook(() => useHiw(), { wrapper: wrap() });
+    // effect runs on mount; allow flush
+    await act(async () => {});
+    expect(result.current.reducedMotion).toBe(true);
+  });
+
+  it('stays false when matchMedia is unavailable (SSR-safe fallback)', () => {
+    // @ts-expect-error — simulate missing matchMedia
+    window.matchMedia = undefined;
+    const { result } = renderHook(() => useHiw(), { wrapper: wrap() });
+    expect(result.current.reducedMotion).toBe(false);
+  });
+});
+
+describe('HiwProvider composition', () => {
+  it('renders children without touching DOM', () => {
+    const { container } = render(
+      <HiwProvider>
+        <span data-testid="child">hi</span>
+      </HiwProvider>,
+    );
+    expect(container.querySelector('[data-testid="child"]')).toBeTruthy();
+  });
+});

--- a/apps/web/src/features/homepage/HowItWorks/context/HiwContext.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/context/HiwContext.tsx
@@ -21,9 +21,9 @@ import {
   createContext,
   useCallback,
   useContext,
-  useEffect,
   useMemo,
   useState,
+  useSyncExternalStore,
   type ReactNode,
 } from 'react';
 import type { PhaseIndex } from '../data/types';
@@ -45,6 +45,41 @@ export interface HiwProviderProps {
   initialOutcome?: OutcomeId | null;
 }
 
+// --- prefers-reduced-motion external store ---------------------------------
+//
+// useSyncExternalStore is the React-recommended path for subscribing to
+// browser-native stores (matchMedia / online status / etc.). It sidesteps
+// the `react-hooks/set-state-in-effect` foot-gun that a useEffect-based
+// subscription hits — the store itself drives updates, so React can never
+// schedule a cascading render from synchronous setState in the effect body.
+// Both the subscribe function and the snapshot getter are stable module
+// references so memoized subscribers never re-register.
+
+function subscribeReducedMotion(callback: () => void): () => void {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return () => {};
+  }
+  const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+  if (typeof mq.addEventListener === 'function') {
+    mq.addEventListener('change', callback);
+    return () => mq.removeEventListener('change', callback);
+  }
+  // Older Safari lacks addEventListener on MediaQueryList
+  mq.addListener(callback);
+  return () => mq.removeListener(callback);
+}
+
+function getReducedMotionSnapshot(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false;
+  }
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+function getReducedMotionServerSnapshot(): boolean {
+  return false;
+}
+
 export function HiwProvider({
   children,
   initialPhase = 0,
@@ -52,23 +87,11 @@ export function HiwProvider({
 }: HiwProviderProps) {
   const [phase, setPhaseState] = useState<PhaseIndex>(initialPhase);
   const [outcome, setOutcomeState] = useState<OutcomeId | null>(initialOutcome);
-  const [reducedMotion, setReducedMotion] = useState(false);
-
-  useEffect(() => {
-    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
-      return;
-    }
-    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
-    setReducedMotion(mq.matches);
-    const handler = (event: MediaQueryListEvent) => setReducedMotion(event.matches);
-    // Older Safari lacks addEventListener on MediaQueryList
-    if (typeof mq.addEventListener === 'function') {
-      mq.addEventListener('change', handler);
-      return () => mq.removeEventListener('change', handler);
-    }
-    mq.addListener(handler);
-    return () => mq.removeListener(handler);
-  }, []);
+  const reducedMotion = useSyncExternalStore(
+    subscribeReducedMotion,
+    getReducedMotionSnapshot,
+    getReducedMotionServerSnapshot,
+  );
 
   const setPhase = useCallback((next: PhaseIndex) => setPhaseState(next), []);
   const setOutcome = useCallback(

--- a/apps/web/src/features/homepage/HowItWorks/context/HiwContext.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/context/HiwContext.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+/**
+ * HiwContext — single source of truth for the How It Works section state.
+ *
+ * Owns:
+ *   - `phase`         · happy-path pinned-timeline position (0..4).
+ *   - `outcome`       · which Safeguards branch is active, or `null` for
+ *                       the default happy path (Delivery resolution).
+ *   - `reducedMotion` · mirrors prefers-reduced-motion so any component
+ *                       can gate animations without re-evaluating media
+ *                       queries (and so unit tests can force a path).
+ *
+ * Data-attribute contract published to downstream lanes:
+ *   - `data-hiw-phase="0..4"`           — happy-path phase
+ *   - `data-hiw-outcome="<OutcomeId>|happy"` — active branch
+ *   - `data-hiw-reduced-motion="true|false"` — for CSS selector hooks
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import type { PhaseIndex } from '../data/types';
+import type { OutcomeId } from '../data/outcomes';
+
+export interface HiwContextValue {
+  phase: PhaseIndex;
+  setPhase: (phase: PhaseIndex) => void;
+  outcome: OutcomeId | null;
+  setOutcome: (outcome: OutcomeId | null) => void;
+  reducedMotion: boolean;
+}
+
+const HiwContext = createContext<HiwContextValue | null>(null);
+
+export interface HiwProviderProps {
+  children: ReactNode;
+  initialPhase?: PhaseIndex;
+  initialOutcome?: OutcomeId | null;
+}
+
+export function HiwProvider({
+  children,
+  initialPhase = 0,
+  initialOutcome = null,
+}: HiwProviderProps) {
+  const [phase, setPhaseState] = useState<PhaseIndex>(initialPhase);
+  const [outcome, setOutcomeState] = useState<OutcomeId | null>(initialOutcome);
+  const [reducedMotion, setReducedMotion] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return;
+    }
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setReducedMotion(mq.matches);
+    const handler = (event: MediaQueryListEvent) => setReducedMotion(event.matches);
+    // Older Safari lacks addEventListener on MediaQueryList
+    if (typeof mq.addEventListener === 'function') {
+      mq.addEventListener('change', handler);
+      return () => mq.removeEventListener('change', handler);
+    }
+    mq.addListener(handler);
+    return () => mq.removeListener(handler);
+  }, []);
+
+  const setPhase = useCallback((next: PhaseIndex) => setPhaseState(next), []);
+  const setOutcome = useCallback(
+    (next: OutcomeId | null) => setOutcomeState(next),
+    [],
+  );
+
+  const value = useMemo<HiwContextValue>(
+    () => ({ phase, setPhase, outcome, setOutcome, reducedMotion }),
+    [phase, setPhase, outcome, setOutcome, reducedMotion],
+  );
+
+  return <HiwContext.Provider value={value}>{children}</HiwContext.Provider>;
+}
+
+export function useHiw(): HiwContextValue {
+  const value = useContext(HiwContext);
+  if (!value) {
+    throw new Error('useHiw must be used inside <HiwProvider>');
+  }
+  return value;
+}

--- a/apps/web/src/features/homepage/HowItWorks/data/contract-map.test.ts
+++ b/apps/web/src/features/homepage/HowItWorks/data/contract-map.test.ts
@@ -75,16 +75,19 @@ describe('resolutionAppliesFees — matches Escrow.sol:576-586', () => {
   });
 });
 
-describe('resolutionMintsSoulbound — matches Escrow.sol dispute-only mint logic', () => {
-  it('mints soulbound only for middleman-arbitrated outcomes', () => {
+describe('resolutionMintsSoulbound — matches Escrow.sol:594-603 unconditional mint', () => {
+  it('mints on every resolution that runs _resolveDeal', () => {
+    // Escrow.sol:601 mints soulboundNFT unconditionally inside _resolveDeal,
+    // which is called for Delivery, Refund, MiddlemanBuyer, MiddlemanSeller,
+    // and Timeout. Only the cancel path (resolution stays None) skips mint.
+    expect(resolutionMintsSoulbound(ResolutionType.Delivery)).toBe(true);
+    expect(resolutionMintsSoulbound(ResolutionType.Refund)).toBe(true);
     expect(resolutionMintsSoulbound(ResolutionType.MiddlemanBuyer)).toBe(true);
     expect(resolutionMintsSoulbound(ResolutionType.MiddlemanSeller)).toBe(true);
+    expect(resolutionMintsSoulbound(ResolutionType.Timeout)).toBe(true);
   });
 
-  it('does not mint soulbound on happy path or auto-resolution', () => {
-    expect(resolutionMintsSoulbound(ResolutionType.Delivery)).toBe(false);
-    expect(resolutionMintsSoulbound(ResolutionType.Refund)).toBe(false);
-    expect(resolutionMintsSoulbound(ResolutionType.Timeout)).toBe(false);
+  it('does not mint for unresolved / cancelled deals (resolution = None)', () => {
     expect(resolutionMintsSoulbound(ResolutionType.None)).toBe(false);
   });
 });

--- a/apps/web/src/features/homepage/HowItWorks/data/contract-map.test.ts
+++ b/apps/web/src/features/homepage/HowItWorks/data/contract-map.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DealState,
+  ResolutionType,
+  ParticipantRole,
+  DEAL_STATE_LABEL,
+  RESOLUTION_LABEL,
+  resolutionAppliesFees,
+  resolutionMintsSoulbound,
+} from './contract-map';
+
+describe('DealState enum parity with Solidity', () => {
+  it('matches the 9 variants declared in apps/contracts/src/types/DataTypes.sol', () => {
+    expect(DealState.Created).toBe(0);
+    expect(DealState.Joined).toBe(1);
+    expect(DealState.Signed).toBe(2);
+    expect(DealState.Funded).toBe(3);
+    expect(DealState.DeliveryConfirmed).toBe(4);
+    expect(DealState.RefundRequested).toBe(5);
+    expect(DealState.Disputed).toBe(6);
+    expect(DealState.Resolved).toBe(7);
+    expect(DealState.TimedOut).toBe(8);
+  });
+
+  it('has a human label for every variant', () => {
+    for (let i = 0; i <= 8; i += 1) {
+      expect(DEAL_STATE_LABEL[i as DealState]).toBeTruthy();
+    }
+  });
+});
+
+describe('ResolutionType enum parity with Solidity', () => {
+  it('has None as the zero value (unresolved default)', () => {
+    expect(ResolutionType.None).toBe(0);
+  });
+
+  it('matches the 6 variants declared in Solidity', () => {
+    expect(ResolutionType.None).toBe(0);
+    expect(ResolutionType.Delivery).toBe(1);
+    expect(ResolutionType.Refund).toBe(2);
+    expect(ResolutionType.MiddlemanBuyer).toBe(3);
+    expect(ResolutionType.MiddlemanSeller).toBe(4);
+    expect(ResolutionType.Timeout).toBe(5);
+  });
+
+  it('has a human label for every variant', () => {
+    for (let i = 0; i <= 5; i += 1) {
+      expect(RESOLUTION_LABEL[i as ResolutionType]).toBeTruthy();
+    }
+  });
+});
+
+describe('ParticipantRole enum parity', () => {
+  it('matches the 3 variants declared in Solidity', () => {
+    expect(ParticipantRole.Client).toBe(0);
+    expect(ParticipantRole.Seller).toBe(1);
+    expect(ParticipantRole.Middleman).toBe(2);
+  });
+});
+
+describe('resolutionAppliesFees — matches Escrow.sol:576-586', () => {
+  it('returns true ONLY for seller-win outcomes', () => {
+    expect(resolutionAppliesFees(ResolutionType.Delivery)).toBe(true);
+    expect(resolutionAppliesFees(ResolutionType.MiddlemanSeller)).toBe(true);
+  });
+
+  it('returns false for every client-win outcome', () => {
+    expect(resolutionAppliesFees(ResolutionType.Refund)).toBe(false);
+    expect(resolutionAppliesFees(ResolutionType.MiddlemanBuyer)).toBe(false);
+    expect(resolutionAppliesFees(ResolutionType.Timeout)).toBe(false);
+  });
+
+  it('returns false for the unresolved default', () => {
+    expect(resolutionAppliesFees(ResolutionType.None)).toBe(false);
+  });
+});
+
+describe('resolutionMintsSoulbound — matches Escrow.sol dispute-only mint logic', () => {
+  it('mints soulbound only for middleman-arbitrated outcomes', () => {
+    expect(resolutionMintsSoulbound(ResolutionType.MiddlemanBuyer)).toBe(true);
+    expect(resolutionMintsSoulbound(ResolutionType.MiddlemanSeller)).toBe(true);
+  });
+
+  it('does not mint soulbound on happy path or auto-resolution', () => {
+    expect(resolutionMintsSoulbound(ResolutionType.Delivery)).toBe(false);
+    expect(resolutionMintsSoulbound(ResolutionType.Refund)).toBe(false);
+    expect(resolutionMintsSoulbound(ResolutionType.Timeout)).toBe(false);
+    expect(resolutionMintsSoulbound(ResolutionType.None)).toBe(false);
+  });
+});

--- a/apps/web/src/features/homepage/HowItWorks/data/contract-map.ts
+++ b/apps/web/src/features/homepage/HowItWorks/data/contract-map.ts
@@ -1,0 +1,82 @@
+/**
+ * Contract-accurate enums ported from
+ * `apps/contracts/src/types/DataTypes.sol`. These drive the UI ledger
+ * chips, event-log labels, and outcome branch dispatch so the homepage
+ * narrative stays 1:1 with the on-chain state machine.
+ *
+ * Zero-indexed to match Solidity enum ordering — any drift from the
+ * Solidity source is a bug (see data/contract-map.test.ts).
+ */
+
+export enum DealState {
+  Created = 0,
+  Joined = 1,
+  Signed = 2,
+  Funded = 3,
+  DeliveryConfirmed = 4,
+  RefundRequested = 5,
+  Disputed = 6,
+  Resolved = 7,
+  TimedOut = 8,
+}
+
+export enum ResolutionType {
+  None = 0,
+  Delivery = 1,
+  Refund = 2,
+  MiddlemanBuyer = 3,
+  MiddlemanSeller = 4,
+  Timeout = 5,
+}
+
+export enum ParticipantRole {
+  Client = 0,
+  Seller = 1,
+  Middleman = 2,
+}
+
+export const DEAL_STATE_LABEL: Record<DealState, string> = {
+  [DealState.Created]: 'Created',
+  [DealState.Joined]: 'Joined',
+  [DealState.Signed]: 'Signed',
+  [DealState.Funded]: 'Funded',
+  [DealState.DeliveryConfirmed]: 'Delivery Confirmed',
+  [DealState.RefundRequested]: 'Refund Requested',
+  [DealState.Disputed]: 'Disputed',
+  [DealState.Resolved]: 'Resolved',
+  [DealState.TimedOut]: 'Timed Out',
+};
+
+export const RESOLUTION_LABEL: Record<ResolutionType, string> = {
+  [ResolutionType.None]: 'Unresolved',
+  [ResolutionType.Delivery]: 'Delivery',
+  [ResolutionType.Refund]: 'Refund',
+  [ResolutionType.MiddlemanBuyer]: 'Middleman · Buyer',
+  [ResolutionType.MiddlemanSeller]: 'Middleman · Seller',
+  [ResolutionType.Timeout]: 'Timeout',
+};
+
+/**
+ * Fees are deducted ONLY when the seller wins (Escrow.sol:576-586).
+ * Client-win resolutions (Refund, MiddlemanBuyer, Timeout) credit the
+ * full amount to the client with zero fees.
+ */
+export function resolutionAppliesFees(resolution: ResolutionType): boolean {
+  return (
+    resolution === ResolutionType.Delivery ||
+    resolution === ResolutionType.MiddlemanSeller
+  );
+}
+
+/**
+ * Every resolution mints one ReceiptNFT for the client + one for the
+ * seller. SoulboundNFT only mints when the middleman actually ruled
+ * (dispute outcomes) — not on happy-path delivery, mutual refund, or
+ * permissionless timeout.
+ */
+export function resolutionMintsSoulbound(resolution: ResolutionType): boolean {
+  return (
+    resolution === ResolutionType.MiddlemanBuyer ||
+    resolution === ResolutionType.MiddlemanSeller
+  );
+}

--- a/apps/web/src/features/homepage/HowItWorks/data/contract-map.ts
+++ b/apps/web/src/features/homepage/HowItWorks/data/contract-map.ts
@@ -69,14 +69,17 @@ export function resolutionAppliesFees(resolution: ResolutionType): boolean {
 }
 
 /**
- * Every resolution mints one ReceiptNFT for the client + one for the
- * seller. SoulboundNFT only mints when the middleman actually ruled
- * (dispute outcomes) — not on happy-path delivery, mutual refund, or
- * permissionless timeout.
+ * `_resolveDeal` (Escrow.sol:594-603) mints three NFTs unconditionally
+ * whenever it runs — a ReceiptNFT for the client, a ReceiptNFT for the
+ * seller, and a SoulboundNFT for the middleman. The try/catch wrapping
+ * means a failed mint never reverts the payout but the default behavior
+ * is to mint on every resolution.
+ *
+ * The only way to reach a resolution WITHOUT `_resolveDeal` running is
+ * `cancelDeal` (pre-funding), which leaves `resolution = None`. So the
+ * soulbound mints for Delivery / Refund / MiddlemanBuyer /
+ * MiddlemanSeller / Timeout — everything except `None`.
  */
 export function resolutionMintsSoulbound(resolution: ResolutionType): boolean {
-  return (
-    resolution === ResolutionType.MiddlemanBuyer ||
-    resolution === ResolutionType.MiddlemanSeller
-  );
+  return resolution !== ResolutionType.None;
 }

--- a/apps/web/src/features/homepage/HowItWorks/data/geometry.ts
+++ b/apps/web/src/features/homepage/HowItWorks/data/geometry.ts
@@ -1,0 +1,11 @@
+import type { ActorId } from './types';
+
+export const SVG_VIEW_BOX = { width: 1200, height: 720 };
+
+export const ACTOR_POSITIONS: Record<ActorId, { x: number; y: number }> = {
+  client: { x: 180, y: 420 },
+  mid: { x: 600, y: 120 },
+  seller: { x: 1020, y: 420 },
+};
+
+export const CORE_POSITION = { x: 600, y: 380 };

--- a/apps/web/src/features/homepage/HowItWorks/data/index.ts
+++ b/apps/web/src/features/homepage/HowItWorks/data/index.ts
@@ -1,0 +1,4 @@
+export * from './types';
+export * from './geometry';
+export * from './phases';
+export * from './ledger-logs';

--- a/apps/web/src/features/homepage/HowItWorks/data/index.ts
+++ b/apps/web/src/features/homepage/HowItWorks/data/index.ts
@@ -2,3 +2,5 @@ export * from './types';
 export * from './geometry';
 export * from './phases';
 export * from './ledger-logs';
+export * from './contract-map';
+export * from './outcomes';

--- a/apps/web/src/features/homepage/HowItWorks/data/ledger-logs.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/data/ledger-logs.tsx
@@ -1,0 +1,23 @@
+import { Fragment, type ReactNode } from 'react';
+
+export interface LedgerLog {
+  time: string;
+  label: ReactNode;
+  hash: string;
+}
+
+export const LEDGER_LOGS: LedgerLog[] = [
+  { time: '00:00', label: 'Parties connected', hash: '0x7a…e91c' },
+  { time: '00:42', label: 'Terms signed ×3', hash: '0x4b…11de' },
+  { time: '01:18', label: '2,400 USDC locked', hash: '0xd2…77ab' },
+  { time: '03:24', label: 'Delivery confirmed', hash: '0x92…501f' },
+  {
+    time: '03:36',
+    label: (
+      <Fragment>
+        Released · <em>3 receipts minted</em>
+      </Fragment>
+    ),
+    hash: '0xfe…c001',
+  },
+];

--- a/apps/web/src/features/homepage/HowItWorks/data/outcomes.test.ts
+++ b/apps/web/src/features/homepage/HowItWorks/data/outcomes.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { HIW_OUTCOMES, getOutcome } from './outcomes';
+import { DealState, ResolutionType, resolutionAppliesFees } from './contract-map';
+
+describe('HIW_OUTCOMES', () => {
+  it('exposes exactly the four safeguard scenarios', () => {
+    const ids = HIW_OUTCOMES.map((o) => o.id).sort();
+    expect(ids).toEqual(['disputeBuyer', 'disputeSeller', 'refund', 'timeout']);
+  });
+
+  it('never includes the happy-path Delivery resolution (that is the default timeline)', () => {
+    const resolutions = HIW_OUTCOMES.map((o) => o.resolution);
+    expect(resolutions).not.toContain(ResolutionType.Delivery);
+  });
+
+  it('keeps feeApplies aligned with the on-chain fee rule', () => {
+    for (const outcome of HIW_OUTCOMES) {
+      expect(outcome.feeApplies).toBe(resolutionAppliesFees(outcome.resolution));
+    }
+  });
+
+  it('maps winners to the correct side for each resolution', () => {
+    expect(getOutcome('refund').winner).toBe('client');
+    expect(getOutcome('disputeBuyer').winner).toBe('client');
+    expect(getOutcome('disputeSeller').winner).toBe('seller');
+    expect(getOutcome('timeout').winner).toBe('client');
+  });
+
+  it('uses DealState.TimedOut for the timeout branch (other branches land on Resolved)', () => {
+    expect(getOutcome('timeout').finalState).toBe(DealState.TimedOut);
+    expect(getOutcome('refund').finalState).toBe(DealState.Resolved);
+    expect(getOutcome('disputeBuyer').finalState).toBe(DealState.Resolved);
+    expect(getOutcome('disputeSeller').finalState).toBe(DealState.Resolved);
+  });
+
+  it('includes a fee note for every outcome', () => {
+    for (const outcome of HIW_OUTCOMES) {
+      expect(outcome.feeNote.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('getOutcome', () => {
+  it('returns the matching outcome by id', () => {
+    expect(getOutcome('refund').resolution).toBe(ResolutionType.Refund);
+  });
+
+  it('throws for an unknown id', () => {
+    // @ts-expect-error — deliberately passing a bad id
+    expect(() => getOutcome('nope')).toThrow();
+  });
+});

--- a/apps/web/src/features/homepage/HowItWorks/data/outcomes.ts
+++ b/apps/web/src/features/homepage/HowItWorks/data/outcomes.ts
@@ -1,0 +1,82 @@
+import { DealState, ResolutionType } from './contract-map';
+
+/**
+ * The four "Safeguards" outcomes surfaced beneath the pinned happy-path
+ * timeline. Each tab swaps the scene in-place, replaying the vault →
+ * recipient flow for that specific `ResolutionType`. Delivery (the happy
+ * path) is NOT in this list — it's the default timeline.
+ */
+export type OutcomeId = 'refund' | 'disputeBuyer' | 'disputeSeller' | 'timeout';
+
+export interface HiwOutcome {
+  id: OutcomeId;
+  chipLabel: string;
+  narrTitle: string;
+  narrBody: string;
+  finalState: DealState;
+  resolution: ResolutionType;
+  feeApplies: boolean;
+  feeNote: string;
+  /**
+   * Which party ends up with the escrowed funds in `_pendingBalances`
+   * (the seller-win flag controls the 3-bucket split visual).
+   */
+  winner: 'client' | 'seller';
+}
+
+export const HIW_OUTCOMES: readonly HiwOutcome[] = [
+  {
+    id: 'refund',
+    chipLabel: 'Refund',
+    narrTitle: 'Seller accepts the refund.',
+    narrBody:
+      'Client requests a refund, seller agrees. Full amount credited back to the client — no middleman, no fees.',
+    finalState: DealState.Resolved,
+    resolution: ResolutionType.Refund,
+    feeApplies: false,
+    feeNote: 'No fees · nothing moved finally',
+    winner: 'client',
+  },
+  {
+    id: 'disputeBuyer',
+    chipLabel: 'Dispute → Buyer',
+    narrTitle: 'Middleman rules for the buyer.',
+    narrBody:
+      'Client requests refund, seller rejects, middleman arbitrates — and sides with the client. Full amount returns to the client. The middleman earns a soulbound NFT, not money.',
+    finalState: DealState.Resolved,
+    resolution: ResolutionType.MiddlemanBuyer,
+    feeApplies: false,
+    feeNote: 'No fees · buyer protection',
+    winner: 'client',
+  },
+  {
+    id: 'disputeSeller',
+    chipLabel: 'Dispute → Seller',
+    narrTitle: 'Middleman rules for the seller.',
+    narrBody:
+      'Same dispute, opposite verdict. Seller payout, middleman commission, platform fee — same split as a clean delivery.',
+    finalState: DealState.Resolved,
+    resolution: ResolutionType.MiddlemanSeller,
+    feeApplies: true,
+    feeNote: 'Fees apply · same as delivery',
+    winner: 'seller',
+  },
+  {
+    id: 'timeout',
+    chipLabel: 'Timeout',
+    narrTitle: 'Deadline passes. Anyone rescues the client.',
+    narrBody:
+      'If nobody moves before the deadline, anyone on-chain can call `executeTimeout` and the vault refunds the client. Permissionless, always free.',
+    finalState: DealState.TimedOut,
+    resolution: ResolutionType.Timeout,
+    feeApplies: false,
+    feeNote: 'No fees · permissionless rescue',
+    winner: 'client',
+  },
+] as const;
+
+export function getOutcome(id: OutcomeId): HiwOutcome {
+  const match = HIW_OUTCOMES.find((o) => o.id === id);
+  if (!match) throw new Error(`Unknown HIW outcome: ${id}`);
+  return match;
+}

--- a/apps/web/src/features/homepage/HowItWorks/data/phases.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/data/phases.tsx
@@ -1,50 +1,5 @@
-// v6 HIW step data — copy verbatim from Blue Escrow v6.html:1487-1523.
-//
-// Each phase drives the narration text, the ledger state chip, the ledger
-// amount, the active rail button, the active actor, and the GSAP timeline
-// choreography (wire activation, packet flight, amount tween).
-
-import type { ReactNode } from 'react';
 import { Fragment } from 'react';
-
-export type LedgerState = 'draft' | 'signed' | 'locked' | 'delivered' | 'released';
-
-export type ActorId = 'client' | 'mid' | 'seller';
-export type WireId = 'C' | 'M' | 'S';
-
-export const PHASE_COUNT = 5;
-export type PhaseIndex = 0 | 1 | 2 | 3 | 4;
-
-export interface HiwChoreo {
-  /** Which active-overlay wires are lit this phase (C = client↔core, M = mid↔core, S = seller↔core) */
-  wiresActive: WireId[];
-  /** Where the money packet starts this phase. null = hidden */
-  packetFrom: 'client' | 'core' | null;
-  /** Where the money packet ends this phase. null = hidden */
-  packetTo: 'core' | 'seller' | null;
-  /** Tween the ledger amount display from -> to over the phase sub-timeline */
-  amountTween?: { from: number; to: number };
-  /** Pulse/glow the central contract core */
-  coreGlow?: 'idle' | 'locked' | 'released';
-}
-
-export interface HiwStep {
-  index: 0 | 1 | 2 | 3 | 4;
-  rail: { num: string; label: string };
-  narr: {
-    step: string;
-    title: ReactNode;
-    body: string;
-  };
-  ledger: {
-    state: LedgerState;
-    stateLabel: string;
-    amount: number;
-    activeLogIndex: number;
-  };
-  activeActor: 'all' | ActorId | null;
-  choreo: HiwChoreo;
-}
+import type { HiwStep } from './types';
 
 export const HIW_STEPS: HiwStep[] = [
   {
@@ -177,34 +132,5 @@ export const HIW_STEPS: HiwStep[] = [
       packetTo: 'seller',
       coreGlow: 'released',
     },
-  },
-];
-
-// SVG viewBox coordinates (v6 HTML:1390-1483 uses viewBox="0 0 1200 720")
-// Actor positions below match the translate() on each actor <g> in v6.
-export const SVG_VIEW_BOX = { width: 1200, height: 720 };
-
-export const ACTOR_POSITIONS: Record<ActorId, { x: number; y: number }> = {
-  client: { x: 180, y: 420 },
-  mid: { x: 600, y: 120 },
-  seller: { x: 1020, y: 420 },
-};
-
-// Contract core position
-export const CORE_POSITION = { x: 600, y: 380 };
-
-export const LEDGER_LOGS: { time: string; label: ReactNode; hash: string }[] = [
-  { time: '00:00', label: 'Parties connected', hash: '0x7a…e91c' },
-  { time: '00:42', label: 'Terms signed ×3', hash: '0x4b…11de' },
-  { time: '01:18', label: '2,400 USDC locked', hash: '0xd2…77ab' },
-  { time: '03:24', label: 'Delivery confirmed', hash: '0x92…501f' },
-  {
-    time: '03:36',
-    label: (
-      <Fragment>
-        Released · <em>3 receipts minted</em>
-      </Fragment>
-    ),
-    hash: '0xfe…c001',
   },
 ];

--- a/apps/web/src/features/homepage/HowItWorks/data/types.ts
+++ b/apps/web/src/features/homepage/HowItWorks/data/types.ts
@@ -1,0 +1,35 @@
+import type { ReactNode } from 'react';
+
+export type LedgerState = 'draft' | 'signed' | 'locked' | 'delivered' | 'released';
+
+export type ActorId = 'client' | 'mid' | 'seller';
+export type WireId = 'C' | 'M' | 'S';
+
+export const PHASE_COUNT = 5;
+export type PhaseIndex = 0 | 1 | 2 | 3 | 4;
+
+export interface HiwChoreo {
+  wiresActive: WireId[];
+  packetFrom: 'client' | 'core' | null;
+  packetTo: 'core' | 'seller' | null;
+  amountTween?: { from: number; to: number };
+  coreGlow?: 'idle' | 'locked' | 'released';
+}
+
+export interface HiwStep {
+  index: 0 | 1 | 2 | 3 | 4;
+  rail: { num: string; label: string };
+  narr: {
+    step: string;
+    title: ReactNode;
+    body: string;
+  };
+  ledger: {
+    state: LedgerState;
+    stateLabel: string;
+    amount: number;
+    activeLogIndex: number;
+  };
+  activeActor: 'all' | ActorId | null;
+  choreo: HiwChoreo;
+}

--- a/apps/web/src/features/homepage/HowItWorks/svg/ActorGroup.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/svg/ActorGroup.tsx
@@ -1,0 +1,90 @@
+import type { ReactNode } from 'react';
+import styles from '../HowItWorks.module.scss';
+
+export type ActorKind = 'client' | 'mid' | 'seller';
+
+interface ActorGroupProps {
+  kind: ActorKind;
+  x: number;
+  y: number;
+  role: string;
+  name: string;
+  meta: string;
+  /**
+   * The glyph drawn inside the puck. Keep stroke/fill identical to the
+   * v7 render: stroke="#0091FF", strokeWidth="1.6", fill="none" on the
+   * parent <g>. Only the path `d` attributes differ per actor.
+   */
+  glyph: ReactNode;
+}
+
+/**
+ * One party puck (Client / Middleman / Seller). v8 commit 5 promotes the
+ * middleman out of this component into a JudgePodium with its own
+ * elevated geometry — this component then owns only Client + Seller.
+ */
+export function ActorGroup({ kind, x, y, role, name, meta, glyph }: ActorGroupProps) {
+  return (
+    <g
+      data-hiw={`actor-${kind}`}
+      transform={`translate(${x} ${y})`}
+      opacity="0"
+    >
+      <circle r="56" className={styles.hiw__diagActorPuck} strokeWidth="1" />
+      <circle
+        r="66"
+        fill="none"
+        stroke="#0091FF"
+        strokeOpacity=".3"
+        strokeDasharray="2 5"
+        vectorEffect="non-scaling-stroke"
+        aria-hidden="true"
+      />
+      <g
+        stroke="#0091FF"
+        strokeWidth="1.6"
+        fill="none"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        {glyph}
+      </g>
+      <text
+        y="-92"
+        textAnchor="middle"
+        className={styles.hiw__diagActorRole}
+      >
+        {role}
+      </text>
+      <text y="100" textAnchor="middle" className={styles.hiw__diagActorText}>
+        {name}
+      </text>
+      <text
+        y="132"
+        textAnchor="middle"
+        className={styles.hiw__diagActorMuted}
+      >
+        {meta}
+      </text>
+    </g>
+  );
+}
+
+export const CLIENT_GLYPH = (
+  <path d="M 0 -16 L -14 -8 V 6 C -14 16 -8 22 0 24 C 8 22 14 16 14 6 V -8 Z" />
+);
+
+export const MIDDLEMAN_GLYPH = (
+  <>
+    <path d="M 0 -18 L 16 -10 V 8 L 0 20 L -16 8 V -10 Z" />
+    <path d="M -16 -2 L 16 -2" />
+  </>
+);
+
+export const SELLER_GLYPH = (
+  <>
+    <path d="M -14 -12 H 14 L 18 14 A 2 2 0 0 1 16 16 H -16 A 2 2 0 0 1 -18 14 Z" />
+    <path d="M -6 -12 V -18 A 6 6 0 0 1 6 -18 V -12" />
+  </>
+);

--- a/apps/web/src/features/homepage/HowItWorks/svg/JudgePodium.test.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/svg/JudgePodium.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { JudgePodium } from './JudgePodium';
+
+afterEach(cleanup);
+
+function renderInSvg() {
+  return render(
+    <svg>
+      <JudgePodium />
+    </svg>,
+  );
+}
+
+describe('JudgePodium', () => {
+  it('keeps data-hiw="actor-mid" so the Meet-phase opacity tween still targets it', () => {
+    const { container } = renderInSvg();
+    const judge = container.querySelector('[data-hiw="actor-mid"]');
+    expect(judge).not.toBeNull();
+  });
+
+  it('adds data-hiw-role="judge" so dispute branches can target the new geometry', () => {
+    const { container } = renderInSvg();
+    const judge = container.querySelector('[data-hiw-role="judge"]');
+    expect(judge).not.toBeNull();
+  });
+
+  it('renders the sticky "Can vote · Cannot withdraw" chip label', () => {
+    const { container } = renderInSvg();
+    const chipLabel = Array.from(container.querySelectorAll('text')).find(
+      (el) => el.textContent?.includes('Can vote · Cannot withdraw'),
+    );
+    expect(chipLabel).toBeTruthy();
+  });
+
+  it('renders MIDDLEMAN / @archer / REP label set (no regression on actor-row labels)', () => {
+    const { container } = renderInSvg();
+    const texts = Array.from(container.querySelectorAll('text')).map((el) =>
+      el.textContent?.trim(),
+    );
+    expect(texts).toContain('MIDDLEMAN');
+    expect(texts).toContain('@archer');
+    expect(texts?.some((t) => t?.startsWith('REP'))).toBe(true);
+  });
+
+  it('wraps the visible body in a group that consumes --hiw-judge-opacity', () => {
+    // The body uses a module-scoped class name, so we assert by class presence
+    // on the inner `<g>` rather than by resolved opacity (jsdom does not
+    // compute CSS custom properties).
+    const { container } = renderInSvg();
+    const judge = container.querySelector('[data-hiw-role="judge"]');
+    expect(judge).not.toBeNull();
+    const body = judge?.querySelector(':scope > g');
+    expect(body).not.toBeNull();
+    // module-scoped class names include the BEM base
+    expect(body?.getAttribute('class')).toMatch(/diagJudgeBody/);
+  });
+});

--- a/apps/web/src/features/homepage/HowItWorks/svg/JudgePodium.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/svg/JudgePodium.tsx
@@ -1,0 +1,128 @@
+import styles from '../HowItWorks.module.scss';
+
+/**
+ * Middleman judge-podium — replaces the v7 symmetric `actor-mid` puck.
+ *
+ * Visual hierarchy: the middleman sits on a raised dais with a
+ * hexagonal badge and a gavel glyph, signalling *referee*, not
+ * counterparty. A sticky pill below the name reads "Can vote · Cannot
+ * withdraw" — the single strongest anti-confusion signal for Web3 users.
+ *
+ * Two-layer opacity contract:
+ *   - Outer `<g data-hiw="judge" opacity="0">`
+ *       · Owned by GSAP. Tweened 0 → 1 during the Meet phase just like
+ *         the original actor-mid. Happy-path cleanup seeds it back.
+ *   - Inner `.hiw__diagJudgeBody`
+ *       · Owned by CSS. `opacity: var(--hiw-judge-opacity, 0.30)`.
+ *         Kept dim on the happy path (referee is on standby). Dispute
+ *         branch timelines lift the var to 1.0 — see commit 9.
+ *
+ * Keeping the two opacities multiplicative means GSAP only needs to
+ * care about entrance/exit; the branch never fights the scrub.
+ */
+export function JudgePodium() {
+  return (
+    <g
+      data-hiw="actor-mid"
+      data-hiw-role="judge"
+      transform="translate(600 120)"
+      opacity="0"
+    >
+      <g className={styles.hiw__diagJudgeBody}>
+        {/* Elevated dais beneath the badge — two layered trapezoids for
+            a shallow perspective suggestion. Dashed top edge nods to
+            the wire system without stealing attention. */}
+        <g
+          className={styles.hiw__diagJudgePodium}
+          aria-hidden="true"
+        >
+          <path d="M -62 60 L 62 60 L 80 84 L -80 84 Z" />
+          <path
+            d="M -52 60 L 52 60"
+            strokeDasharray="4 5"
+            vectorEffect="non-scaling-stroke"
+          />
+        </g>
+
+        {/* Hexagonal badge — flat-top hex radius 56 centered at (0,0)
+            to match the actor puck radius so the horizontal axis of
+            the diagram stays visually balanced. */}
+        <polygon
+          className={styles.hiw__diagJudgeHex}
+          points="56,0 28,-48.5 -28,-48.5 -56,0 -28,48.5 28,48.5"
+          strokeWidth="1"
+        />
+
+        {/* Gavel + strike block — paths scoped inside a rotated group so
+            the head reads as angled, not upright. */}
+        <g className={styles.hiw__diagJudgeGavel} aria-hidden="true">
+          <g transform="rotate(-20)">
+            <rect x="-18" y="-22" width="26" height="10" rx="2" />
+            <rect x="-2" y="-14" width="4" height="28" rx="1.5" />
+          </g>
+          <rect
+            className={styles.hiw__diagJudgeGavelBlock}
+            x="-18"
+            y="18"
+            width="36"
+            height="4"
+            rx="1"
+          />
+        </g>
+
+        {/* Scales-of-justice accents — two short arcs flanking the hex
+            at y=0, echoing the dashed orbits without introducing a new
+            stroke weight. */}
+        <g
+          className={styles.hiw__diagJudgeScales}
+          aria-hidden="true"
+        >
+          <path d="M -82 -4 A 18 18 0 0 1 -58 -4" />
+          <path d="M 58 -4 A 18 18 0 0 1 82 -4" />
+        </g>
+
+        {/* Role label — same y-offset as the actor pucks so the CLIENT /
+            MIDDLEMAN / SELLER trio reads on one baseline. */}
+        <text
+          y="-92"
+          textAnchor="middle"
+          className={styles.hiw__diagActorRole}
+        >
+          MIDDLEMAN
+        </text>
+        <text y="100" textAnchor="middle" className={styles.hiw__diagActorText}>
+          @archer
+        </text>
+        <text
+          y="132"
+          textAnchor="middle"
+          className={styles.hiw__diagActorMuted}
+        >
+          REP 4.98 · 214 deals
+        </text>
+
+        {/* Sticky role chip — the load-bearing signal for this whole
+            redesign. Short, monospaced, two-column with a · separator
+            so the negative claim ("cannot withdraw") gets equal read
+            weight to the positive ("can vote"). */}
+        <g transform="translate(0 160)">
+          <rect
+            className={styles.hiw__diagJudgeChip}
+            x="-112"
+            y="-14"
+            width="224"
+            height="28"
+            rx="14"
+          />
+          <text
+            y="5"
+            textAnchor="middle"
+            className={styles.hiw__diagJudgeChipLabel}
+          >
+            Can vote · Cannot withdraw
+          </text>
+        </g>
+      </g>
+    </g>
+  );
+}

--- a/apps/web/src/features/homepage/HowItWorks/svg/MoneyPacket.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/svg/MoneyPacket.tsx
@@ -1,0 +1,31 @@
+import styles from '../HowItWorks.module.scss';
+
+/**
+ * Money packet animated along the MotionPath set by the master timeline.
+ * GSAP owns its transform — never set translate() inline here, or scrub-
+ * back would fight the tween.
+ */
+export function MoneyPacket() {
+  return (
+    <g data-hiw="packet" opacity="0" filter="url(#hiw-packet-trail)">
+      <rect
+        x="-28"
+        y="-14"
+        width="56"
+        height="28"
+        rx="14"
+        fill="#fff"
+        stroke="#0091FF"
+        strokeWidth="1.5"
+      />
+      <text
+        textAnchor="middle"
+        y="5"
+        fill="#001B4D"
+        className={styles.hiw__diagPacket}
+      >
+        $2,400
+      </text>
+    </g>
+  );
+}

--- a/apps/web/src/features/homepage/HowItWorks/svg/VaultCore.test.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/svg/VaultCore.test.tsx
@@ -64,6 +64,23 @@ describe('VaultCore — v8 hex chamber + pending-balance buckets', () => {
     expect(cue?.textContent).toMatch(/withdraw\(\)/);
   });
 
+  it('renders the client-refund cue (fee-free outcomes) at data-hiw="vault-refund-cue"', () => {
+    const { container } = renderInSvg();
+    const refund = container.querySelector('[data-hiw="vault-refund-cue"]');
+    expect(refund).not.toBeNull();
+    expect(refund?.textContent).toMatch(/CLIENT REFUND/);
+    expect(refund?.textContent).toMatch(/2,400/);
+  });
+
+  it('renders the soulbound mint badge at data-hiw="vault-soulbound-cue"', () => {
+    const { container } = renderInSvg();
+    const soulbound = container.querySelector(
+      '[data-hiw="vault-soulbound-cue"]',
+    );
+    expect(soulbound).not.toBeNull();
+    expect(soulbound?.textContent).toMatch(/SOULBOUND/);
+  });
+
   it('keeps the v7 "SMART CONTRACT / Escrow #4821" labels (no regression)', () => {
     const { container } = renderInSvg();
     const texts = Array.from(container.querySelectorAll('text')).map((t) =>

--- a/apps/web/src/features/homepage/HowItWorks/svg/VaultCore.test.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/svg/VaultCore.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { VaultCore } from './VaultCore';
+
+afterEach(cleanup);
+
+function renderInSvg() {
+  return render(
+    <svg>
+      <VaultCore />
+    </svg>,
+  );
+}
+
+describe('VaultCore — v8 hex chamber + pending-balance buckets', () => {
+  it('preserves data-hiw="core" + data-hiw="core-halo" so GSAP tweens still bind', () => {
+    const { container } = renderInSvg();
+    expect(container.querySelector('[data-hiw="core"]')).not.toBeNull();
+    expect(container.querySelector('[data-hiw="core-halo"]')).not.toBeNull();
+  });
+
+  it('adds data-hiw="core-chamber" for --hiw-vault-charge plumbing', () => {
+    const { container } = renderInSvg();
+    const chamber = container.querySelector('[data-hiw="core-chamber"]');
+    expect(chamber).not.toBeNull();
+    expect(chamber?.tagName.toLowerCase()).toBe('polygon');
+  });
+
+  it('renders three dashed output spouts (client, seller, platform)', () => {
+    const { container } = renderInSvg();
+    expect(container.querySelector('[data-hiw="spout-client"]')).not.toBeNull();
+    expect(container.querySelector('[data-hiw="spout-seller"]')).not.toBeNull();
+    expect(container.querySelector('[data-hiw="spout-platform"]')).not.toBeNull();
+  });
+
+  it('renders three pending-balance buckets keyed by recipient, hidden by default', () => {
+    const { container } = renderInSvg();
+    for (const id of [
+      'vault-bucket-seller',
+      'vault-bucket-middleman',
+      'vault-bucket-platform',
+    ]) {
+      const bucket = container.querySelector(`[data-hiw="${id}"]`);
+      expect(bucket, `bucket ${id} missing`).not.toBeNull();
+      // class name is BEM-hashed by CSS Modules; substring match is enough
+      expect(bucket?.getAttribute('class')).toMatch(/diagVaultBucket/);
+    }
+  });
+
+  it('encodes the seller-win fee-split amounts in the bucket labels', () => {
+    const { container } = renderInSvg();
+    const texts = Array.from(container.querySelectorAll('text')).map((t) =>
+      t.textContent?.trim(),
+    );
+    expect(texts).toContain('2,344.08');
+    expect(texts).toContain('48.00');
+    expect(texts).toContain('7.92');
+  });
+
+  it('renders the pull-based withdraw cue tied to data-hiw="vault-withdraw-cue"', () => {
+    const { container } = renderInSvg();
+    const cue = container.querySelector('[data-hiw="vault-withdraw-cue"]');
+    expect(cue).not.toBeNull();
+    expect(cue?.textContent).toMatch(/withdraw\(\)/);
+  });
+
+  it('keeps the v7 "SMART CONTRACT / Escrow #4821" labels (no regression)', () => {
+    const { container } = renderInSvg();
+    const texts = Array.from(container.querySelectorAll('text')).map((t) =>
+      t.textContent?.trim(),
+    );
+    expect(texts).toContain('SMART CONTRACT');
+    expect(texts).toContain('Escrow #4821');
+  });
+});

--- a/apps/web/src/features/homepage/HowItWorks/svg/VaultCore.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/svg/VaultCore.tsx
@@ -210,7 +210,8 @@ export function VaultCore() {
 
       {/* Pull-based withdraw cue — footnote-scale reminder that every
           recipient has to call withdraw() themselves. Stays hidden until
-          the Settle → Payout tail of the master timeline. */}
+          the Settle → Payout tail of the master timeline, or any
+          Safeguards branch (outcome-active=1). */}
       <text
         data-hiw="vault-withdraw-cue"
         x="600"
@@ -220,6 +221,68 @@ export function VaultCore() {
       >
         EACH PARTY PULLS VIA withdraw()
       </text>
+
+      {/* Client-refund cue — single pill that replaces the 3-bucket
+          split on fee-free outcomes (refund / disputeBuyer / timeout).
+          Centered between the Client puck and the vault so the return-
+          direction reads left (matches the wire-C geometry in
+          WireNetwork.tsx). CSS handles the exclusive show/hide math via
+          --hiw-fee-applies. */}
+      <g
+        data-hiw="vault-refund-cue"
+        className={styles.hiw__diagVaultRefundCue}
+      >
+        <rect
+          x="500"
+          y="555"
+          width="200"
+          height="42"
+          rx="10"
+          className={styles.hiw__diagVaultRefundPill}
+        />
+        <text
+          x="600"
+          y="574"
+          textAnchor="middle"
+          className={styles.hiw__diagVaultRefundLabel}
+        >
+          CLIENT REFUND
+        </text>
+        <text
+          x="600"
+          y="590"
+          textAnchor="middle"
+          className={styles.hiw__diagVaultRefundAmount}
+        >
+          2,400.00
+        </text>
+      </g>
+
+      {/* Soulbound mint badge — appears only on dispute outcomes
+          (MiddlemanBuyer / MiddlemanSeller) per resolutionMintsSoulbound
+          in contract-map.ts. The tiny badge sits below the judge podium
+          area to visually attribute the mint to the middleman's vote. */}
+      <g
+        data-hiw="vault-soulbound-cue"
+        className={styles.hiw__diagSoulboundCue}
+        transform="translate(860 250)"
+      >
+        <rect
+          x="-60"
+          y="-14"
+          width="120"
+          height="28"
+          rx="14"
+          className={styles.hiw__diagSoulboundBadge}
+        />
+        <text
+          y="5"
+          textAnchor="middle"
+          className={styles.hiw__diagSoulboundLabel}
+        >
+          ⬡ SOULBOUND NFT
+        </text>
+      </g>
     </g>
   );
 }

--- a/apps/web/src/features/homepage/HowItWorks/svg/VaultCore.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/svg/VaultCore.tsx
@@ -1,22 +1,31 @@
-import styles from '../HowItWorks.module.scss';
+import coreStyles from '../HowItWorks.module.scss';
+import styles from './hiw-svg.module.scss';
 
 /**
- * Smart-contract core — the "vault" at the center of the diagram.
+ * Smart-contract core rendered as a hexagonal **vault** with an inner
+ * chamber, a padlock glyph, three dashed output spouts (client, seller,
+ * platform/middleman), and three pending-balance **buckets** that reveal
+ * during the Settle phase.
  *
- * Layers (outer → inner):
- *   1. `core-halo`   — large glow disc, fill-opacity tweened up/down
- *                      across Fund/Deliver/Release phases.
- *   2. ring          — dashed outline, static.
- *   3. core disc     — solid gradient disc with padlock glyph.
- *   4. text labels   — "SMART CONTRACT" + "Escrow #4821".
+ * Data-attribute contract preserved so the existing HowItWorksAnimations
+ * tween plumbing keeps working byte-for-byte:
+ *   - `[data-hiw="core"]`         outer group (halo-fade tween target)
+ *   - `[data-hiw="core-halo"]`    halo circle (fillOpacity tween)
+ *   - `[data-hiw="core-chamber"]` inner hex — new in v8, consumed by
+ *                                  `--hiw-vault-charge` CSS var for the
+ *                                  empty → charged transition
+ *   - `[data-hiw="vault-bucket-<seller|middleman|platform>"]` per-payee
+ *                                  pending-balance slots, hidden at rest
+ *   - `[data-hiw="vault-withdraw-cue"]` footnote-style cue that reads
+ *                                  "Each party pulls via withdraw()"
  *
- * Commit 6 replaces the circular core with a hexagonal vault + internal
- * pending-balances chamber; until then this preserves the v7 render
- * byte-for-byte so snapshot tests stay green.
+ * The buckets and withdraw cue start with `opacity: 0`; commit 12 wires
+ * the GSAP tweens that raise them during the fee-split cinematic.
  */
 export function VaultCore() {
   return (
     <g data-hiw="core">
+      {/* Soft radial glow — fillOpacity tweened by the master timeline */}
       <circle
         data-hiw="core-halo"
         cx="600"
@@ -27,6 +36,8 @@ export function VaultCore() {
         filter="url(#hiw-core-glow)"
         aria-hidden="true"
       />
+
+      {/* Decorative dashed ring preserved from v7 for continuity */}
       <circle
         cx="600"
         cy="380"
@@ -38,31 +49,153 @@ export function VaultCore() {
         vectorEffect="non-scaling-stroke"
         aria-hidden="true"
       />
+
+      {/* Outer hex shell — reads as "vault" surface */}
+      <polygon
+        points="660,380 630,430 570,430 540,380 570,330 630,330"
+        className={styles.hiw__diagVaultHex}
+      />
+
+      {/* Inner chamber fill — opacity/fill driven by --hiw-vault-charge
+          so the vault visibly "fills" during the Fund phase */}
+      <polygon
+        data-hiw="core-chamber"
+        points="652,380 624,424 576,424 548,380 576,336 624,336"
+        className={styles.hiw__diagVaultChamber}
+      />
+
+      {/* Gradient core disc — v7 signature glow, now inside the hex */}
       <circle
         cx="600"
         cy="380"
-        r="60"
+        r="42"
         fill="url(#hiw-core-grad)"
         stroke="#0091FF"
         strokeWidth="1"
       />
+
+      {/* Padlock glyph — rendered with stroke-only tokens via the
+          shared padlock class so forced-colors inherits --text */}
       <g
+        className={styles.hiw__diagVaultPadlock}
         transform="translate(600 380)"
-        fill="none"
-        stroke="#fff"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
         aria-hidden="true"
       >
-        <rect x="-14" y="-4" width="28" height="20" rx="3" />
-        <path d="M -9 -4 V -10 A 9 9 0 0 1 9 -10 V -4" />
+        <rect x="-11" y="-3" width="22" height="16" rx="2.5" />
+        <path d="M -7 -3 V -8 A 7 7 0 0 1 7 -8 V -3" />
       </g>
+
+      {/* Output spouts — dashed channels pointing toward each recipient
+          side. Stay dim until the Settle phase lights them up. */}
+      <g aria-hidden="true">
+        <path
+          data-hiw="spout-client"
+          d="M 540 380 L 470 380"
+          className={styles.hiw__diagVaultSpout}
+        />
+        <path
+          data-hiw="spout-seller"
+          d="M 660 380 L 730 380"
+          className={styles.hiw__diagVaultSpout}
+        />
+        <path
+          data-hiw="spout-platform"
+          d="M 600 430 L 600 500"
+          className={styles.hiw__diagVaultSpout}
+        />
+      </g>
+
+      {/* Pending-balances buckets — three slot pills laid out below the
+          vault (settle phase). Each starts opacity 0 so snapshot-style
+          happy-path tests see the same visual as pre-redesign until the
+          timeline seeds them. */}
+      <g data-hiw="vault-bucket-seller" className={styles.hiw__diagVaultBucket}>
+        <rect
+          x="455"
+          y="555"
+          width="100"
+          height="42"
+          rx="10"
+          className={styles.hiw__diagVaultBucketPill}
+        />
+        <text
+          x="505"
+          y="574"
+          textAnchor="middle"
+          className={styles.hiw__diagVaultBucketLabel}
+        >
+          SELLER
+        </text>
+        <text
+          x="505"
+          y="590"
+          textAnchor="middle"
+          className={styles.hiw__diagVaultBucketAmount}
+        >
+          2,344.08
+        </text>
+      </g>
+
+      <g data-hiw="vault-bucket-middleman" className={styles.hiw__diagVaultBucket}>
+        <rect
+          x="560"
+          y="555"
+          width="100"
+          height="42"
+          rx="10"
+          className={styles.hiw__diagVaultBucketPill}
+        />
+        <text
+          x="610"
+          y="574"
+          textAnchor="middle"
+          className={styles.hiw__diagVaultBucketLabel}
+        >
+          MIDDLEMAN
+        </text>
+        <text
+          x="610"
+          y="590"
+          textAnchor="middle"
+          className={styles.hiw__diagVaultBucketAmount}
+        >
+          48.00
+        </text>
+      </g>
+
+      <g data-hiw="vault-bucket-platform" className={styles.hiw__diagVaultBucket}>
+        <rect
+          x="665"
+          y="555"
+          width="100"
+          height="42"
+          rx="10"
+          className={styles.hiw__diagVaultBucketPill}
+        />
+        <text
+          x="715"
+          y="574"
+          textAnchor="middle"
+          className={styles.hiw__diagVaultBucketLabel}
+        >
+          PLATFORM
+        </text>
+        <text
+          x="715"
+          y="590"
+          textAnchor="middle"
+          className={styles.hiw__diagVaultBucketAmount}
+        >
+          7.92
+        </text>
+      </g>
+
+      {/* "SMART CONTRACT / Escrow #4821" labels preserved from v7 */}
       <text
         x="600"
         y="468"
         textAnchor="middle"
-        className={styles.hiw__diagCoreLabel}
+        className={coreStyles.hiw__diagCoreLabel}
       >
         SMART CONTRACT
       </text>
@@ -70,9 +203,22 @@ export function VaultCore() {
         x="600"
         y="498"
         textAnchor="middle"
-        className={styles.hiw__diagCoreTitle}
+        className={coreStyles.hiw__diagCoreTitle}
       >
         Escrow #4821
+      </text>
+
+      {/* Pull-based withdraw cue — footnote-scale reminder that every
+          recipient has to call withdraw() themselves. Stays hidden until
+          the Settle → Payout tail of the master timeline. */}
+      <text
+        data-hiw="vault-withdraw-cue"
+        x="600"
+        y="624"
+        textAnchor="middle"
+        className={styles.hiw__diagVaultWithdrawCue}
+      >
+        EACH PARTY PULLS VIA withdraw()
       </text>
     </g>
   );

--- a/apps/web/src/features/homepage/HowItWorks/svg/VaultCore.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/svg/VaultCore.tsx
@@ -1,0 +1,79 @@
+import styles from '../HowItWorks.module.scss';
+
+/**
+ * Smart-contract core — the "vault" at the center of the diagram.
+ *
+ * Layers (outer → inner):
+ *   1. `core-halo`   — large glow disc, fill-opacity tweened up/down
+ *                      across Fund/Deliver/Release phases.
+ *   2. ring          — dashed outline, static.
+ *   3. core disc     — solid gradient disc with padlock glyph.
+ *   4. text labels   — "SMART CONTRACT" + "Escrow #4821".
+ *
+ * Commit 6 replaces the circular core with a hexagonal vault + internal
+ * pending-balances chamber; until then this preserves the v7 render
+ * byte-for-byte so snapshot tests stay green.
+ */
+export function VaultCore() {
+  return (
+    <g data-hiw="core">
+      <circle
+        data-hiw="core-halo"
+        cx="600"
+        cy="380"
+        r="110"
+        fill="#0091FF"
+        fillOpacity="0"
+        filter="url(#hiw-core-glow)"
+        aria-hidden="true"
+      />
+      <circle
+        cx="600"
+        cy="380"
+        r="85"
+        fill="none"
+        stroke="#0091FF"
+        strokeOpacity=".5"
+        strokeDasharray="4 5"
+        vectorEffect="non-scaling-stroke"
+        aria-hidden="true"
+      />
+      <circle
+        cx="600"
+        cy="380"
+        r="60"
+        fill="url(#hiw-core-grad)"
+        stroke="#0091FF"
+        strokeWidth="1"
+      />
+      <g
+        transform="translate(600 380)"
+        fill="none"
+        stroke="#fff"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <rect x="-14" y="-4" width="28" height="20" rx="3" />
+        <path d="M -9 -4 V -10 A 9 9 0 0 1 9 -10 V -4" />
+      </g>
+      <text
+        x="600"
+        y="468"
+        textAnchor="middle"
+        className={styles.hiw__diagCoreLabel}
+      >
+        SMART CONTRACT
+      </text>
+      <text
+        x="600"
+        y="498"
+        textAnchor="middle"
+        className={styles.hiw__diagCoreTitle}
+      >
+        Escrow #4821
+      </text>
+    </g>
+  );
+}

--- a/apps/web/src/features/homepage/HowItWorks/svg/WireNetwork.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/svg/WireNetwork.tsx
@@ -1,0 +1,97 @@
+import styles from '../HowItWorks.module.scss';
+
+/**
+ * Wires + decorative orbits around the contract core.
+ *
+ * Two layers per wire:
+ *   - `wire-base-<C|M|S>` · always visible dashed path (CSS styled).
+ *   - `wire-active-<C|M|S>` · opacity-tweened gradient overlay that
+ *     lights up during the phase that involves that actor. Phase 12
+ *     will also run a perpetual strokeDashoffset flow on the active
+ *     wire; see HowItWorksAnimations.tsx.
+ *
+ * Orbits fade in at phase 0 (Meet) as ambient decoration.
+ */
+export function WireNetwork() {
+  return (
+    <>
+      {/* Concentric orbits around the contract core — decorative. */}
+      <g data-hiw="orbits" opacity="0" aria-hidden="true">
+        <circle
+          cx="600"
+          cy="380"
+          r="180"
+          fill="none"
+          stroke="#0091FF"
+          strokeOpacity=".15"
+          strokeDasharray="2 6"
+          vectorEffect="non-scaling-stroke"
+        />
+        <circle
+          cx="600"
+          cy="380"
+          r="260"
+          fill="none"
+          stroke="#0091FF"
+          strokeOpacity=".1"
+          strokeDasharray="2 8"
+          vectorEffect="non-scaling-stroke"
+        />
+        <circle
+          cx="600"
+          cy="380"
+          r="340"
+          fill="none"
+          stroke="#0091FF"
+          strokeOpacity=".07"
+          strokeDasharray="2 10"
+          vectorEffect="non-scaling-stroke"
+        />
+      </g>
+
+      {/* Wires — base dashed (always visible) + active gradient overlays (tweened) */}
+      <g strokeLinecap="round" fill="none" strokeWidth="1.5" aria-hidden="true">
+        <path
+          data-hiw="wire-base-C"
+          className={styles.hiw__diagWire}
+          d="M 260 420 Q 420 420 540 400"
+          strokeDasharray="5 6"
+        />
+        <path
+          data-hiw="wire-base-M"
+          className={styles.hiw__diagWire}
+          d="M 600 180 Q 600 280 600 340"
+          strokeDasharray="5 6"
+        />
+        <path
+          data-hiw="wire-base-S"
+          className={styles.hiw__diagWire}
+          d="M 940 420 Q 780 420 660 400"
+          strokeDasharray="5 6"
+        />
+
+        <path
+          data-hiw="wire-active-C"
+          d="M 260 420 Q 420 420 540 400"
+          stroke="url(#hiw-wire-grad)"
+          strokeWidth="2"
+          opacity="0"
+        />
+        <path
+          data-hiw="wire-active-M"
+          d="M 600 180 Q 600 280 600 340"
+          stroke="url(#hiw-wire-grad)"
+          strokeWidth="2"
+          opacity="0"
+        />
+        <path
+          data-hiw="wire-active-S"
+          d="M 940 420 Q 780 420 660 400"
+          stroke="url(#hiw-wire-grad)"
+          strokeWidth="2"
+          opacity="0"
+        />
+      </g>
+    </>
+  );
+}

--- a/apps/web/src/features/homepage/HowItWorks/svg/defs.tsx
+++ b/apps/web/src/features/homepage/HowItWorks/svg/defs.tsx
@@ -1,0 +1,61 @@
+/**
+ * Shared SVG <defs> — gradients + filters referenced by url(#...) across
+ * the diagram. Kept in one file so later commits can add vault, judge,
+ * and fee-split gradients without mutating the WireNetwork or VaultCore
+ * files.
+ */
+export function HiwDefs() {
+  return (
+    <defs>
+      <radialGradient id="hiw-core-grad" cx="50%" cy="40%" r="60%">
+        <stop offset="0" stopColor="#33AAFF" />
+        <stop offset="60%" stopColor="#0066FF" />
+        <stop offset="100%" stopColor="#001B4D" />
+      </radialGradient>
+      <filter
+        id="hiw-core-glow"
+        x="-50%"
+        y="-50%"
+        width="200%"
+        height="200%"
+      >
+        <feGaussianBlur stdDeviation="8" result="b" />
+        <feMerge>
+          <feMergeNode in="b" />
+          <feMergeNode in="SourceGraphic" />
+        </feMerge>
+      </filter>
+      <linearGradient id="hiw-wire-grad" x1="0" x2="1">
+        <stop offset="0" stopColor="#0091FF" stopOpacity="0" />
+        <stop offset=".5" stopColor="#0091FF" />
+        <stop offset="1" stopColor="#0091FF" stopOpacity="0" />
+      </linearGradient>
+      <filter
+        id="hiw-packet-trail"
+        x="-50%"
+        y="-50%"
+        width="200%"
+        height="200%"
+      >
+        <feGaussianBlur in="SourceGraphic" stdDeviation="0" />
+      </filter>
+      <filter
+        id="hiw-core-rim"
+        x="-50%"
+        y="-50%"
+        width="200%"
+        height="200%"
+      >
+        <feGaussianBlur in="SourceAlpha" stdDeviation="3" />
+        <feOffset dx="0" dy="0" />
+        <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1" />
+        <feColorMatrix values="0 0 0 0 0.2  0 0 0 0 0.67  0 0 0 0 1  0 0 0 1 0" />
+        <feComposite in2="SourceGraphic" operator="in" />
+        <feMerge>
+          <feMergeNode />
+          <feMergeNode in="SourceGraphic" />
+        </feMerge>
+      </filter>
+    </defs>
+  );
+}

--- a/apps/web/src/features/homepage/HowItWorks/svg/hiw-svg.module.scss
+++ b/apps/web/src/features/homepage/HowItWorks/svg/hiw-svg.module.scss
@@ -1,0 +1,170 @@
+@use '../../../../styles/settings/variables' as *;
+
+// ---------------------------------------------------------------------------
+// SVG-scoped styles for the Live Contract View.
+//
+// Colocated next to the SVG subcomponents so HowItWorks.module.scss stays
+// lean. Every class uses BEM `.hiw__diag<...>` naming, matching the
+// existing tokens in HowItWorks.module.scss (--hiw-actor-bg,
+// --hiw-actor-border, --hiw-role-label) so dark/light theme cascade from
+// the cookie-driven SSR provider still applies.
+//
+// CSS custom properties (fallbacks in `var()` so the module works without
+// an ancestor setting them):
+//   --hiw-judge-opacity  · 0.3 happy-path standby, 1 dispute active
+//   --hiw-vault-charge   · 0 empty vault, 1 fully charged (post-Fund)
+//   --hiw-vault-split    · 0 monolithic balance, 1 split into buckets
+// ---------------------------------------------------------------------------
+
+// --- JudgePodium ------------------------------------------------------------
+
+.hiw__diagJudgeBody {
+  opacity: var(--hiw-judge-opacity, 0.3);
+  transition: opacity var(--dur-default, 500ms) var(--ease-out-expo, cubic-bezier(0.19, 1, 0.22, 1));
+}
+
+.hiw__diagJudgePodium {
+  fill: color-mix(in oklch, var(--hiw-actor-bg) 65%, transparent);
+  stroke: var(--hiw-actor-border);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+
+.hiw__diagJudgeHex {
+  fill: var(--hiw-actor-bg);
+  stroke: var(--hiw-actor-border);
+}
+
+.hiw__diagJudgeGavel {
+  fill: var(--hiw-role-label);
+  stroke: none;
+}
+
+.hiw__diagJudgeGavelBlock {
+  fill: color-mix(in oklch, var(--hiw-role-label) 45%, transparent);
+}
+
+.hiw__diagJudgeScales {
+  fill: none;
+  stroke: var(--hiw-role-label);
+  stroke-width: 1.2;
+  stroke-opacity: 0.55;
+  stroke-linecap: round;
+  vector-effect: non-scaling-stroke;
+}
+
+.hiw__diagJudgeChip {
+  fill: color-mix(in oklch, var(--hiw-actor-bg) 80%, transparent);
+  stroke: var(--hiw-actor-border);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+
+.hiw__diagJudgeChipLabel {
+  fill: var(--hiw-role-label);
+  font-family: var(--ff-mono);
+  // Container-query sized so 320px mobile stays readable; ceiling 14 keeps
+  // the pill shorter than the 224px chip width at desktop scale.
+  font-size: clamp(11px, 1.7cqi, 14px);
+  font-weight: 500;
+  letter-spacing: 0.04em;
+}
+
+// --- VaultCore (commit 6) ---------------------------------------------------
+
+.hiw__diagVaultHex {
+  fill: var(--hiw-actor-bg);
+  stroke: var(--hiw-actor-border);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+
+.hiw__diagVaultChamber {
+  // Inner fill intensity follows charge level: empty vault is translucent,
+  // fully charged vault saturates to brand-blue.
+  fill: color-mix(
+    in oklch,
+    var(--blue-vivid, #0091ff) calc(var(--hiw-vault-charge, 0) * 45%),
+    transparent
+  );
+  transition:
+    fill var(--dur-cinematic, 900ms) var(--ease-out-expo, cubic-bezier(0.19, 1, 0.22, 1));
+}
+
+.hiw__diagVaultPadlock {
+  fill: none;
+  stroke: var(--muted-2, var(--text-muted));
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.hiw__diagVaultSpout {
+  stroke: var(--hiw-wire-base);
+  stroke-width: 1.25;
+  stroke-dasharray: 3 4;
+  fill: none;
+  opacity: 0.55;
+  vector-effect: non-scaling-stroke;
+}
+
+.hiw__diagVaultBucket {
+  // Pending-balance slot — hidden by default, GSAP tweens opacity to 1
+  // during the Settle phase. Scale tween hooks off the same data-hiw id.
+  opacity: 0;
+}
+
+.hiw__diagVaultBucketPill {
+  fill: color-mix(in oklch, var(--hiw-actor-bg) 85%, transparent);
+  stroke: var(--hiw-actor-border);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+
+.hiw__diagVaultBucketLabel {
+  fill: var(--hiw-role-label);
+  font-family: var(--ff-mono);
+  font-size: clamp(10px, 1.4cqi, 13px);
+  font-weight: 500;
+  letter-spacing: 0.06em;
+}
+
+.hiw__diagVaultBucketAmount {
+  fill: var(--text);
+  font-family: var(--ff-mono);
+  font-size: clamp(12px, 1.8cqi, 16px);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.hiw__diagVaultWithdrawCue {
+  fill: var(--muted-2, var(--text-muted));
+  font-family: var(--ff-mono);
+  // Smaller-than-core-title so this reads as footnote, not headline.
+  font-size: clamp(11px, 1.55cqi, 14px);
+  letter-spacing: 0.08em;
+  opacity: 0;
+}
+
+// --- prefers-contrast: more -------------------------------------------------
+
+@media (prefers-contrast: more) {
+  .hiw__diagJudgeChipLabel,
+  .hiw__diagJudgeGavel,
+  .hiw__diagVaultBucketLabel,
+  .hiw__diagVaultWithdrawCue {
+    fill: var(--text);
+  }
+  .hiw__diagJudgeScales {
+    stroke: var(--text);
+  }
+}
+
+// --- prefers-reduced-motion -------------------------------------------------
+
+@media (prefers-reduced-motion: reduce) {
+  .hiw__diagJudgeBody,
+  .hiw__diagVaultChamber {
+    transition: none;
+  }
+}

--- a/apps/web/src/features/homepage/HowItWorks/svg/hiw-svg.module.scss
+++ b/apps/web/src/features/homepage/HowItWorks/svg/hiw-svg.module.scss
@@ -109,9 +109,27 @@
 }
 
 .hiw__diagVaultBucket {
-  // Pending-balance slot — hidden by default, GSAP tweens opacity to 1
-  // during the Settle phase. Scale tween hooks off the same data-hiw id.
-  opacity: 0;
+  // Pending-balance slot for seller-win payouts. Visible when BOTH an
+  // outcome is active AND fees apply (Delivery / MiddlemanSeller via
+  // Safeguards or scroll). The multiplication acts as logical AND:
+  // happy-path scroll (outcome-active=0) hides the buckets; refund /
+  // disputeBuyer / timeout (fee-applies=0) hides them too.
+  opacity: calc(
+    var(--hiw-outcome-active, 0) * var(--hiw-fee-applies, 0)
+  );
+  transition:
+    opacity var(--dur-cinematic, 900ms) var(--ease-out-expo, cubic-bezier(0.19, 1, 0.22, 1));
+}
+
+.hiw__diagVaultRefundCue {
+  // Single-bucket refund pill for client-win payouts. Visible when an
+  // outcome is active AND fees DON'T apply — refund / disputeBuyer /
+  // timeout. `1 - fee-applies` inverts the Solidity rule cleanly.
+  opacity: calc(
+    var(--hiw-outcome-active, 0) * (1 - var(--hiw-fee-applies, 0))
+  );
+  transition:
+    opacity var(--dur-cinematic, 900ms) var(--ease-out-expo, cubic-bezier(0.19, 1, 0.22, 1));
 }
 
 .hiw__diagVaultBucketPill {
@@ -143,7 +161,59 @@
   // Smaller-than-core-title so this reads as footnote, not headline.
   font-size: clamp(11px, 1.55cqi, 14px);
   letter-spacing: 0.08em;
-  opacity: 0;
+  // Reveal the pull-based withdraw footnote on any Safeguards outcome —
+  // this is the "cannot-be-missed" signal that money is NEVER pushed.
+  opacity: var(--hiw-outcome-active, 0);
+  transition:
+    opacity var(--dur-default, 500ms) var(--ease-out-expo, cubic-bezier(0.19, 1, 0.22, 1));
+}
+
+// --- Client-refund cue — single pill shown on fee-free outcomes --------
+
+.hiw__diagVaultRefundPill {
+  fill: color-mix(in oklch, var(--status-success, #22cc66) 12%, transparent);
+  stroke: var(--status-success, #22cc66);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+
+.hiw__diagVaultRefundLabel {
+  fill: var(--status-success, #22cc66);
+  font-family: var(--ff-mono);
+  font-size: clamp(10px, 1.4cqi, 13px);
+  font-weight: 500;
+  letter-spacing: 0.06em;
+}
+
+.hiw__diagVaultRefundAmount {
+  fill: var(--text);
+  font-family: var(--ff-mono);
+  font-size: clamp(12px, 1.8cqi, 16px);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+// --- Soulbound-mint cue — appears on dispute outcomes ------------------
+
+.hiw__diagSoulboundCue {
+  opacity: var(--hiw-soulbound-mint, 0);
+  transition:
+    opacity var(--dur-default, 500ms) var(--ease-out-expo, cubic-bezier(0.19, 1, 0.22, 1));
+}
+
+.hiw__diagSoulboundBadge {
+  fill: color-mix(in oklch, var(--accent, #0091ff) 18%, transparent);
+  stroke: var(--accent, #0091ff);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+
+.hiw__diagSoulboundLabel {
+  fill: var(--accent, #0091ff);
+  font-family: var(--ff-mono);
+  font-size: clamp(9px, 1.2cqi, 11px);
+  font-weight: 600;
+  letter-spacing: 0.08em;
 }
 
 // --- prefers-contrast: more -------------------------------------------------
@@ -152,7 +222,10 @@
   .hiw__diagJudgeChipLabel,
   .hiw__diagJudgeGavel,
   .hiw__diagVaultBucketLabel,
-  .hiw__diagVaultWithdrawCue {
+  .hiw__diagVaultWithdrawCue,
+  .hiw__diagVaultRefundAmount,
+  .hiw__diagVaultRefundLabel,
+  .hiw__diagSoulboundLabel {
     fill: var(--text);
   }
   .hiw__diagJudgeScales {
@@ -164,7 +237,11 @@
 
 @media (prefers-reduced-motion: reduce) {
   .hiw__diagJudgeBody,
-  .hiw__diagVaultChamber {
+  .hiw__diagVaultChamber,
+  .hiw__diagVaultBucket,
+  .hiw__diagVaultRefundCue,
+  .hiw__diagVaultWithdrawCue,
+  .hiw__diagSoulboundCue {
     transition: none;
   }
 }

--- a/apps/web/src/features/homepage/HowItWorks/svg/index.ts
+++ b/apps/web/src/features/homepage/HowItWorks/svg/index.ts
@@ -1,0 +1,11 @@
+export { HiwDefs } from './defs';
+export { WireNetwork } from './WireNetwork';
+export { VaultCore } from './VaultCore';
+export {
+  ActorGroup,
+  CLIENT_GLYPH,
+  MIDDLEMAN_GLYPH,
+  SELLER_GLYPH,
+  type ActorKind,
+} from './ActorGroup';
+export { MoneyPacket } from './MoneyPacket';

--- a/apps/web/src/features/homepage/HowItWorks/svg/index.ts
+++ b/apps/web/src/features/homepage/HowItWorks/svg/index.ts
@@ -8,4 +8,5 @@ export {
   SELLER_GLYPH,
   type ActorKind,
 } from './ActorGroup';
+export { JudgePodium } from './JudgePodium';
 export { MoneyPacket } from './MoneyPacket';

--- a/e2e/tests/hiw-fee-split.spec.ts
+++ b/e2e/tests/hiw-fee-split.spec.ts
@@ -1,0 +1,97 @@
+import { expect, test } from '@playwright/test';
+import { primeThemeAndSkipPreloader } from './_utils/prime-theme';
+
+// HIW v8 fee-split reveal contract:
+//
+// The pending-balance buckets (seller / middleman / platform) are
+// visible ONLY when the active outcome applies fees — i.e.
+// happy-path scroll end AND disputeSeller. On refund, disputeBuyer,
+// and timeout the single CLIENT REFUND pill replaces them.
+//
+// Visibility is driven by CSS:
+//   .hiw__diagVaultBucket      opacity = outcome-active * fee-applies
+//   .hiw__diagVaultRefundCue   opacity = outcome-active * (1 - fee-applies)
+//
+// This spec exercises each outcome and asserts the right cue is the
+// visible one (opacity ≈ 1) and the other is off (opacity ≈ 0).
+
+async function opacityOf(
+  page: import('@playwright/test').Page,
+  selector: string,
+): Promise<number> {
+  return page.evaluate((sel) => {
+    const el = document.querySelector(sel) as HTMLElement | null;
+    if (!el) return NaN;
+    return parseFloat(getComputedStyle(el).opacity);
+  }, selector);
+}
+
+async function expectOpacity(
+  page: import('@playwright/test').Page,
+  selector: string,
+  expected: number,
+) {
+  await expect
+    .poll(() => opacityOf(page, selector))
+    .toBeCloseTo(expected, 1);
+}
+
+test.describe('HIW · fee-split bucket vs refund cue reveal', () => {
+  test.beforeEach(async ({ page }) => {
+    await primeThemeAndSkipPreloader(page, 'dark');
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/');
+    await page.waitForFunction(
+      () => document.documentElement.dataset.preloader === 'done',
+    );
+    await page.waitForSelector('#hiw');
+    await page.locator('#hiw').scrollIntoViewIfNeeded();
+  });
+
+  test('happy path hides both cues (the scroll timeline will reveal later)', async ({
+    page,
+  }) => {
+    await expectOpacity(page, '[data-hiw="vault-bucket-seller"]', 0);
+    await expectOpacity(page, '[data-hiw="vault-refund-cue"]', 0);
+  });
+
+  test('disputeSeller reveals the three seller-win buckets, hides the refund cue', async ({
+    page,
+  }) => {
+    await page.locator('[data-hiw-outcome-chip="disputeSeller"]').click();
+
+    await expectOpacity(page, '[data-hiw="vault-bucket-seller"]', 1);
+    await expectOpacity(page, '[data-hiw="vault-bucket-middleman"]', 1);
+    await expectOpacity(page, '[data-hiw="vault-bucket-platform"]', 1);
+    await expectOpacity(page, '[data-hiw="vault-refund-cue"]', 0);
+  });
+
+  for (const id of ['refund', 'disputeBuyer', 'timeout'] as const) {
+    test(`${id} reveals the CLIENT REFUND cue, hides the seller-win buckets`, async ({
+      page,
+    }) => {
+      await page.locator(`[data-hiw-outcome-chip="${id}"]`).click();
+
+      await expectOpacity(page, '[data-hiw="vault-refund-cue"]', 1);
+      await expectOpacity(page, '[data-hiw="vault-bucket-seller"]', 0);
+      await expectOpacity(page, '[data-hiw="vault-bucket-middleman"]', 0);
+      await expectOpacity(page, '[data-hiw="vault-bucket-platform"]', 0);
+    });
+  }
+
+  test('SOULBOUND NFT cue reveals on every Safeguards outcome (_resolveDeal always mints)', async ({
+    page,
+  }) => {
+    for (const id of [
+      'refund',
+      'disputeBuyer',
+      'disputeSeller',
+      'timeout',
+    ] as const) {
+      await page.locator(`[data-hiw-outcome-chip="${id}"]`).click();
+      await expectOpacity(page, '[data-hiw="vault-soulbound-cue"]', 1);
+      // Toggle off before the next iteration
+      await page.locator(`[data-hiw-outcome-chip="${id}"]`).click();
+    }
+  });
+});

--- a/e2e/tests/hiw-judge-podium.spec.ts
+++ b/e2e/tests/hiw-judge-podium.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test } from '@playwright/test';
+import { primeThemeAndSkipPreloader } from './_utils/prime-theme';
+
+// HIW v8 JudgePodium opacity contract (CSS custom property
+// --hiw-judge-opacity written by useOutcomeBranch):
+//
+//   happy       · 0.3 (standby — referee never touches happy path)
+//   refund      · 0.3 (seller accepts; middleman idle)
+//   disputeBuyer · 1.0 (middleman rules)
+//   disputeSeller · 1.0 (middleman rules)
+//   timeout     · 0.3 (permissionless rescue; middleman idle)
+//
+// This spec reads the computed --hiw-judge-opacity on the section root
+// after each click so the full chain (context → hook → style prop)
+// stays locked end-to-end in a real browser.
+
+async function readJudgeOpacity(page: import('@playwright/test').Page) {
+  return page.evaluate(() => {
+    const section = document.querySelector('section#hiw') as HTMLElement | null;
+    if (!section) return null;
+    return section.style.getPropertyValue('--hiw-judge-opacity').trim();
+  });
+}
+
+test.describe('HIW · JudgePodium opacity contract', () => {
+  test.beforeEach(async ({ page }) => {
+    await primeThemeAndSkipPreloader(page, 'dark');
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/');
+    await page.waitForFunction(
+      () => document.documentElement.dataset.preloader === 'done',
+    );
+    await page.waitForSelector('#hiw');
+    await page.locator('#hiw').scrollIntoViewIfNeeded();
+  });
+
+  test('happy path keeps the judge dimmed at 0.3', async ({ page }) => {
+    expect(await readJudgeOpacity(page)).toBe('0.3');
+  });
+
+  test('disputeBuyer lifts the judge to full opacity', async ({ page }) => {
+    await page.locator('[data-hiw-outcome-chip="disputeBuyer"]').click();
+    await expect
+      .poll(() => readJudgeOpacity(page))
+      .toBe('1');
+  });
+
+  test('disputeSeller also lifts the judge to full opacity', async ({ page }) => {
+    await page.locator('[data-hiw-outcome-chip="disputeSeller"]').click();
+    await expect
+      .poll(() => readJudgeOpacity(page))
+      .toBe('1');
+  });
+
+  for (const id of ['refund', 'timeout'] as const) {
+    test(`${id} keeps the judge dimmed (middleman idle)`, async ({ page }) => {
+      await page.locator(`[data-hiw-outcome-chip="${id}"]`).click();
+      await expect
+        .poll(() => readJudgeOpacity(page))
+        .toBe('0.3');
+    });
+  }
+
+  test('the sticky chip always reads "Can vote · Cannot withdraw"', async ({
+    page,
+  }) => {
+    const chipLabel = page
+      .locator('section#hiw')
+      .getByText(/Can vote.*Cannot withdraw/i)
+      .first();
+    await expect(chipLabel).toBeVisible();
+  });
+});

--- a/e2e/tests/hiw-outcomes.spec.ts
+++ b/e2e/tests/hiw-outcomes.spec.ts
@@ -1,0 +1,108 @@
+import { expect, test } from '@playwright/test';
+import { primeThemeAndSkipPreloader } from './_utils/prime-theme';
+
+// HIW v8 Safeguards outcome contract:
+//   1. The happy path renders section[data-hiw-outcome="happy"] and every
+//      [data-hiw-outcome-chip] has aria-selected="false".
+//   2. Clicking a chip:
+//        - flips that chip's aria-selected to "true" and all others to "false"
+//        - writes data-hiw-outcome="<id>" on section#hiw
+//        - unhides the matching [data-hiw-outcome-panel] and keeps others hidden
+//        - updates the [data-hiw-outcome-announcer] text
+//   3. Re-clicking the active chip returns the section to happy-path state.
+//
+// Runs at 1440×900 so the desktop stage is guaranteed (min-width 900 +
+// min-height 700 per #96 header-clearance rules).
+
+test.describe('HIW · Safeguards outcome switching', () => {
+  test.beforeEach(async ({ page }) => {
+    await primeThemeAndSkipPreloader(page, 'dark');
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/');
+    await page.waitForFunction(
+      () => document.documentElement.dataset.preloader === 'done',
+    );
+    await page.waitForSelector('#hiw');
+    await page.locator('#hiw').scrollIntoViewIfNeeded();
+  });
+
+  test('default state marks happy-path on section + all chips aria-selected=false', async ({
+    page,
+  }) => {
+    const section = page.locator('section#hiw');
+    await expect(section).toHaveAttribute('data-hiw-outcome', 'happy');
+
+    for (const id of [
+      'refund',
+      'disputeBuyer',
+      'disputeSeller',
+      'timeout',
+    ] as const) {
+      const chip = section.locator(`[data-hiw-outcome-chip="${id}"]`);
+      await expect(chip).toHaveAttribute('aria-selected', 'false');
+    }
+  });
+
+  test.describe('outcome cycling', () => {
+    for (const id of [
+      'refund',
+      'disputeBuyer',
+      'disputeSeller',
+      'timeout',
+    ] as const) {
+      test(`selecting "${id}" flips attributes + reveals matching panel`, async ({
+        page,
+      }) => {
+        const section = page.locator('section#hiw');
+        const chip = section.locator(`[data-hiw-outcome-chip="${id}"]`);
+        await chip.click();
+
+        await expect(chip).toHaveAttribute('aria-selected', 'true');
+        await expect(section).toHaveAttribute('data-hiw-outcome', id);
+
+        const panel = section.locator(`[data-hiw-outcome-panel="${id}"]`);
+        await expect(panel).toBeVisible();
+
+        // Every other panel stays hidden.
+        for (const otherId of [
+          'refund',
+          'disputeBuyer',
+          'disputeSeller',
+          'timeout',
+        ].filter((x) => x !== id)) {
+          const otherPanel = section.locator(
+            `[data-hiw-outcome-panel="${otherId}"]`,
+          );
+          await expect(otherPanel).toBeHidden();
+        }
+      });
+    }
+  });
+
+  test('re-clicking the active chip returns to happy path', async ({ page }) => {
+    const section = page.locator('section#hiw');
+    const chip = section.locator('[data-hiw-outcome-chip="disputeSeller"]');
+
+    await chip.click();
+    await expect(section).toHaveAttribute('data-hiw-outcome', 'disputeSeller');
+
+    await chip.click();
+    await expect(section).toHaveAttribute('data-hiw-outcome', 'happy');
+    await expect(chip).toHaveAttribute('aria-selected', 'false');
+  });
+
+  test('announcer live region updates per outcome', async ({ page }) => {
+    const section = page.locator('section#hiw');
+    const live = section.locator('[data-hiw-outcome-announcer]');
+
+    await expect(live).toHaveAttribute('aria-live', 'polite');
+    await expect(live).toContainText(/happy path active/i);
+
+    await section.locator('[data-hiw-outcome-chip="refund"]').click();
+    await expect(live).toContainText(/Refund outcome selected/i);
+
+    await section.locator('[data-hiw-outcome-chip="disputeSeller"]').click();
+    await expect(live).toContainText(/Dispute/i);
+    await expect(live).toContainText(/Fees apply/i);
+  });
+});

--- a/e2e/tests/hiw-reduced-motion-branches.spec.ts
+++ b/e2e/tests/hiw-reduced-motion-branches.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test } from '@playwright/test';
+import { primeThemeAndSkipPreloader } from './_utils/prime-theme';
+
+// HIW v8 reduced-motion contract:
+//
+//   - CSS transitions on .hiw__diagJudgeBody, .hiw__diagVaultBucket,
+//     .hiw__diagVaultRefundCue, .hiw__diagSoulboundCue etc. are dropped
+//     under prefers-reduced-motion: reduce.
+//   - Final state still lands: opacity values resolve instantly to the
+//     same result a non-reduced-motion user sees after the transition
+//     ends.
+//
+// This spec emulates reduced-motion at the browser level and verifies
+// the final-frame values match their normal counterparts.
+
+async function opacityOf(
+  page: import('@playwright/test').Page,
+  selector: string,
+): Promise<number> {
+  return page.evaluate((sel) => {
+    const el = document.querySelector(sel) as HTMLElement | null;
+    if (!el) return NaN;
+    return parseFloat(getComputedStyle(el).opacity);
+  }, selector);
+}
+
+test.describe('HIW · reduced-motion seed-state parity', () => {
+  test.use({ reducedMotion: 'reduce' });
+
+  test.beforeEach(async ({ page }) => {
+    await primeThemeAndSkipPreloader(page, 'dark');
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/');
+    await page.waitForFunction(
+      () => document.documentElement.dataset.preloader === 'done',
+    );
+    await page.waitForSelector('#hiw');
+    await page.locator('#hiw').scrollIntoViewIfNeeded();
+  });
+
+  test('judge opacity still flips on dispute outcomes (instant, not transitioned)', async ({
+    page,
+  }) => {
+    // Pick the inner body, not the outer <g> (GSAP opacity=0 at rest).
+    const getJudgeBodyOpacity = async () =>
+      page.evaluate(() => {
+        const body = document.querySelector(
+          'section#hiw [data-hiw-role="judge"] > g',
+        ) as HTMLElement | null;
+        if (!body) return NaN;
+        return parseFloat(getComputedStyle(body).opacity);
+      });
+
+    await page.locator('[data-hiw-outcome-chip="disputeBuyer"]').click();
+    // No transition → next tick should already show the final value
+    await expect.poll(() => getJudgeBodyOpacity()).toBeCloseTo(1, 1);
+  });
+
+  test('seller-win buckets land on full opacity instantly on disputeSeller', async ({
+    page,
+  }) => {
+    await page.locator('[data-hiw-outcome-chip="disputeSeller"]').click();
+    await expect
+      .poll(() => opacityOf(page, '[data-hiw="vault-bucket-seller"]'))
+      .toBeCloseTo(1, 1);
+    await expect
+      .poll(() => opacityOf(page, '[data-hiw="vault-bucket-middleman"]'))
+      .toBeCloseTo(1, 1);
+    await expect
+      .poll(() => opacityOf(page, '[data-hiw="vault-bucket-platform"]'))
+      .toBeCloseTo(1, 1);
+  });
+
+  test('refund cue lands on full opacity instantly on refund', async ({
+    page,
+  }) => {
+    await page.locator('[data-hiw-outcome-chip="refund"]').click();
+    await expect
+      .poll(() => opacityOf(page, '[data-hiw="vault-refund-cue"]'))
+      .toBeCloseTo(1, 1);
+  });
+
+  test('withdraw-cue text reveals on every Safeguards outcome', async ({
+    page,
+  }) => {
+    for (const id of [
+      'refund',
+      'disputeBuyer',
+      'disputeSeller',
+      'timeout',
+    ] as const) {
+      await page.locator(`[data-hiw-outcome-chip="${id}"]`).click();
+      await expect
+        .poll(() => opacityOf(page, '[data-hiw="vault-withdraw-cue"]'))
+        .toBeCloseTo(1, 1);
+      await page.locator(`[data-hiw-outcome-chip="${id}"]`).click();
+    }
+  });
+});


### PR DESCRIPTION
Closes #101 · parent epic #38

## Summary

Rediseño del "How It Works" para reflejar el state-machine real del contrato
(`Escrow.sol`, 9 estados + 6 ResolutionTypes) con middleman posicionado como
juez, Safeguards tabs para las cuatro ramas alternativas (Refund, Dispute →
Buyer, Dispute → Seller, Timeout), vault hexagonal con pending-balance
buckets, y animaciones CSS-driven (zero changes al master timeline GSAP).

**14 commits incrementales · 198/198 unit tests ✓ · typecheck ✓ · lint ✓**

## What changed

- \`data/\` · barrel con \`contract-map.ts\` (enums 1:1 con \`DataTypes.sol\`) +
  \`outcomes.ts\` (HIW_OUTCOMES matrix con feeApplies, winner, finalState)
- \`context/HiwContext.tsx\` · single source of truth (phase + outcome +
  reducedMotion via \`useSyncExternalStore\`)
- \`svg/\` · split del HiwDiagram en VaultCore / JudgePodium / ActorGroup /
  WireNetwork / MoneyPacket / defs
- \`animations/useOutcomeBranch.ts\` · CSS-var bridge
  (\`--hiw-judge-opacity\`, \`--hiw-vault-charge\`, \`--hiw-fee-applies\`,
  \`--hiw-outcome-active\`, \`--hiw-soulbound-mint\`)
- \`Safeguards/SafeguardsPanel.tsx\` · aria-tablist de 4 chips con aria-live
  announcer (\`announceOutcome()\` helper)
- VaultCore · buckets (seller/middleman/platform split) + CLIENT REFUND pill
  + SOULBOUND NFT badge
- aria-live region anunciando cambios de outcome (role=status, aria-atomic)
- 4 nuevos e2e specs (\`hiw-outcomes\`, \`hiw-judge-podium\`, \`hiw-fee-split\`,
  \`hiw-reduced-motion-branches\`)
- HowItWorks.integration.test.tsx parametrizado cubriendo la cadena
  Safeguards → section → announcer end-to-end

## Critical review fixes (Descartes)

- Bug en \`resolutionMintsSoulbound()\`: Solidity (\`Escrow.sol:601\`) minta el
  soulbound NFT en TODAS las resoluciones excepto \`None\` (cancelled), no
  solo en disputes. Fixed en commit 6d94436.
- Lint cleanup: \`react-hooks/set-state-in-effect\` en \`HiwContext\` → migrado
  a \`useSyncExternalStore\`. Display-name + unused import limpiados.

## Test plan

- [x] \`pnpm -F @blue-escrow/web typecheck\` clean
- [x] \`pnpm -F @blue-escrow/web lint\` clean
- [x] \`pnpm -F @blue-escrow/web test\` · 198/198 ✓
- [ ] \`pnpm --filter e2e test\` (nuevos specs authoring-complete; ejecución
      en pass siguiente tras merge)
- [ ] Visual baseline refresh atómico (post-merge, si QA manual OK)
- [ ] QA manual: scroll a \`#hiw\`, click cada chip, verificar judge opacity +
      bucket reveal + live region announcement

## Scope isolation

Zero cambios fuera de \`apps/web/src/features/homepage/HowItWorks/**\` y
\`e2e/tests/hiw-*.spec.ts\`. Otras secciones del homepage (Hero, TheProblem,
Compare, Receipts, FAQ, etc.) intactas.